### PR TITLE
Logging handler

### DIFF
--- a/O365/handlers.py
+++ b/O365/handlers.py
@@ -1,0 +1,75 @@
+import logging
+import json
+import copy
+import O365
+
+log = logging.getLogger(__name__)
+
+class O365Handler(logging.Handler):
+	'''
+	Logging handler for sending O365 emails
+	'''
+
+	def __init__(self, *args, **kwargs):
+		'''
+		Creates a new logging handler for sending O365 messages
+
+		The parameters for initialization are the same for O365.Message.
+
+		If the handler is initialized with a JSON parameter, that will be used
+		as a default message structure.
+
+		If a new record has a message that can be deserialized by JSON.loads(),
+		its message will be used to create a new O365 message. If the message
+		can't be deserialized, the message will be appended to the body of the
+		handler's default O365 message.
+
+		If a new record is received and the handler was initialized with a
+		default JSON format, the record's message will be appended to the end
+		of the default messsage's body prior to being sent.
+		'''
+
+		super(O365Handler, self).__init__()
+
+		self._defaultMessage = O365.Message(*args, **kwargs)
+
+	def emit(self, record):
+		'''
+		Handles emitting a record
+
+		Arguments
+		record -- the record to handle
+		'''
+
+		# We'll need to try to use our default message to send this, so start
+		# by making a copy
+		message = copy.deepcopy(self._defaultMessage)
+
+		# If we can deserialize this record's message, use that to try to send
+		# the message
+		try:
+			message.json = json.loads(record.getMessage())
+			message.sendMessage()
+			return
+		except Exception as e:
+			pass
+
+		# There could be a few things missing from the various dictionaries,
+		# and the dictionary layout might change, so just be cheap and wrap
+		# this in a dictionary try/catch.
+		try:
+			defaultMessageBody = self._defaultMessage.getBody()
+
+			# We already have a body, so append to the end
+			message.setBody("{}{}".format(defaultMessageBody, record.getMessage()))
+
+		except KeyError:
+			# We don't have a body yet, so just set the record's message as the
+			# body
+			message.setBody(record.getMessage())
+
+		# Send!
+		try:
+			message.sendMessage()
+		except Exception as e:
+			log.info('Could not send message: {}'.format(str(e)))

--- a/O365/message.py
+++ b/O365/message.py
@@ -12,7 +12,7 @@ class Message(object):
 	Management of the process of sending, receiving, reading, and editing emails.
 
 	Note: the get and set methods are technically superflous. You can get more through control over
-	a message you are trying to craft throught he use of editing the message.json, but these
+	a message you are trying to craft through the use of editing the message.json, but these
 	methods provide an easy way if you don't need all the power and would like the ease.
 
 	Methods:

--- a/O365/message.py
+++ b/O365/message.py
@@ -57,7 +57,7 @@ class Message(object):
 			self.hasAttachments = json['HasAttachments']
 
 		else:
-			self.json = {'Message': {'Body': {}},
+			self.json = {'Body': {},
 									 'ToRecipients': [], 'CcRecipients': [], 'BccRecipients': []}
 			self.hasAttachments = False
 


### PR DESCRIPTION
This is a pretty simple handler for Python's logging package. In my environment at work, we don't really have good access to an SMTP server, so I don't think logging's built-in SMTP handler will work for me. This new handler does work for me, however, as we use O365. I figured having a handler built into O365 might be nice for anyone else using it.

I worked using the language style you already have in message.py as best I could.

I also believe there was an issue with the default self.json assignment for O365.Message(). As far as I can tell, everything else that sets self.json or uses self.json expects 'Body' to be in the self.json dictionary itself, not nested under self.json['Message'], which is what was being done in __init__(). If you initialized with a JSON parameter or you used setBody(), it would fix itself; but if you just tried to add a recipient and send, it would fail on trying to retrieve 'Body'.