### PR TITLE
Support for fluent shared mailboxes, 401 error msg and more

### DIFF
--- a/O365/connection.py
+++ b/O365/connection.py
@@ -217,6 +217,9 @@ class Connection(with_metaclass(Singleton)):
 
 		log.info('Received response from URL {}'.format(response.url))
 
+		if response.status_code == 401:
+			raise RuntimeError('API returned status code 401 Unauthorized, check the connection credentials')
+
 		response_json = response.json()
 		if 'value' not in response_json:
 			raise RuntimeError('Something went wrong, received an unexpected result \n{}'.format(response_json))

--- a/O365/fluent_message.py
+++ b/O365/fluent_message.py
@@ -30,6 +30,7 @@ class Message(object):
 					setRecipients -- sets the list of recipients.
 					setSubject -- sets the subject line.
 					setBody -- sets the body.
+					setCategory -- sets the email's category
 
 	Variables:
 					att_url -- url for requestiong attachments. takes message GUID
@@ -279,13 +280,16 @@ class Message(object):
 			except:
 				self.json['Body'] = {}
 
+	def setCategory(self, category_name, **kwargs):
+		"Sets the email's category"
+		self.update_category(self, category_name, **kwargs)
+
 	def update_category(self, category_name, **kwargs):
 		category = '{{"Categories":["{}"]}}'.format(category_name)
 		headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
 		try:
 			response = requests.patch(self.update_url.format(
 				self.json['Id']), category, headers=headers, auth=self.auth, verify=self.verify, **kwargs)
-			print(response.url)
 		except:
 			return False
 		return True


### PR DESCRIPTION
* Connection: Added HTTP 401 error message instead of throwing misleading error on json decode 
* Fluent message: removed print statement, added setCategory alias function
* Fluent inbox: added support for shared inbox, replaced redundant code with get_mailbox()

