### PR TITLE
Support for shared inbox child folders and updated setup.py for PyPI

### DIFF
--- a/O365/fluent_inbox.py
+++ b/O365/fluent_inbox.py
@@ -31,6 +31,10 @@ class FluentInbox(object):
 		'user_folder': {
 			'1.0': 'https://outlook.office365.com/api/v1.0/users/{user_id}/Folders/{folder_id}/messages',
 			'2.0': 'https://graph.microsoft.com/v1.0/users/{user_id}/MailFolders/{folder_id}/messages',
+		},
+		'user_child_folders': {
+			'1.0': 'https://outlook.office365.com/api/v1.0/users/{user_id}/Folders/{folder_id}/childfolders',
+			'2.0': 'https://graph.microsoft.com/v1.0/users/{user_id}/MailFolders/{folder_id}/childfolders',
 		}
 	}
 
@@ -86,7 +90,10 @@ class FluentInbox(object):
 		:param user_id: user id the folder belongs to (shared mailboxes)
 		:returns: Single folder data
 		"""
-		if parent_id:
+		if parent_id and user_id:
+			folders_url = FluentInbox._get_url('user_child_folders').format(
+				folder_id=parent_id, user_id=user_id)
+		elif parent_id:
 			folders_url = FluentInbox._get_url('child_folders').format(
 				folder_id=parent_id)
 		elif user_id:
@@ -118,7 +125,10 @@ class FluentInbox(object):
 		:param parent_id: Id of parent folder to list.  Default to top folder
 		:return: List of all folder data
 		"""
-		if parent_id:
+		if parent_id and user_id:
+			folders_url = FluentInbox._get_url('user_child_folders').format(
+				folder_id=parent_id, user_id=user_id)
+		elif parent_id:
 			folders_url = FluentInbox._get_url('child_folders').format(
 				folder_id=parent_id)
 		elif user_id:

--- a/setup.py
+++ b/setup.py
@@ -1,50 +1,41 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 CLASSIFIERS = [
-	'Development Status :: 4 - Beta',
-	'Intended Audience :: Developers',
-	'License :: OSI Approved :: Apache Software License',
-	'Topic :: Office/Business :: Office Suites',
-	'Topic :: Software Development :: Libraries'
+    'Development Status :: 4 - Beta',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: Apache Software License',
+    'Topic :: Office/Business :: Office Suites',
+    'Topic :: Software Development :: Libraries'
 ]
-long_desc = '''When I started making this library I was looking for something that would provide a simple interface to an office365 mailbox. I was creating a system that would allow people send an email to our printer without having to require they install drivers or be inside the office firewall (important for students). As I found working with the office API to be fairly easy, I quickly built up solid general use library for working with office 365. 
 
-The objective here is to make it easy to make utilities that are to be run against an office 365 account. for example, the code for sending an email is:
-
-
-from O365 import Message
-
-authenticiation = ('YourAccount@office365.com','YourPassword')
-
-m = Message(auth=authenticiation)
-
-m.setRecipients('reciving@office365.com')
-
-m.setSubject('I made an email script.')
-
-m.setBody('Talk to the computer, cause the human does not want to hear it any more.')
-
-m.sendMessage()
-
-
-That's it. making and sending emails and events is now very simple and straight forward. I've used it for emailing the printer and creating a overview of our car booking system. simple, easy, but still in development. Any suggestions or advice are quite welcome at the projects github page:
-https://github.com/Narcolapser/python-o365'''
+with open("README.md", "r") as fh:
+    long_description = fh.read()
 
 setup(name='O365',
-      version='0.9.14',
+      version='0.9.15',
       description='Python library for working with Microsoft Office 365',
-      long_description=long_desc,
+      long_description=long_description,
+      long_description_content_type="text/markdown",
       author='Toben Archer',
       author_email='sandslash+O365@gmail.com',
-      maintainer='Toben Archer',
-      maintainer_email='sandslash+O365@gmail.com',
       url='https://github.com/Narcolapser/python-o365',
       packages=['O365'],
-      install_requires=['requests', 'oauthlib','requests_oauthlib','future'],
+      install_requires=['requests', 'oauthlib', 'requests_oauthlib', 'future'],
       license='Apache 2.0',
       classifiers=CLASSIFIERS
       )
 
-#so I don't have to keep looking it up: python setup.py sdist upload -r pypi
+"""
+Quick reference:
+
+Generate dist:
+python setup.py sdist bdist_wheel
+
+Upload to TestPyPI
+twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+Upload to PyPI
+twine upload dist/*
+"""


### PR DESCRIPTION
As the title suggests:

* Added support for working with child folders in shared inboxes.
* Updated `setup.py` preparing for a new PyPI release based on [official guide](https://packaging.python.org/tutorials/packaging-projects/)

See new quick reference commands to build and upload at the bottom of `setup.py`