### PR TITLE
Micro dict propogation

### DIFF
--- a/O365/connection.py
+++ b/O365/connection.py
@@ -17,6 +17,8 @@ class MicroDict(dict):
 		result = super(MicroDict, self).get(key[:1].lower() + key[1:], None)
 		if result is None:
 			result = super(MicroDict, self).get(key[:1].upper() + key[1:])
+		if type(result) is dict:
+			result = MicroDict(result)
 		return result
 
 
@@ -211,7 +213,7 @@ class Connection(with_metaclass(Singleton)):
 				response = connection.oauth.get(request_url, **con_params)
 			except TokenExpiredError:
 				log.info('Token is expired, fetching a new token')
-				token = connection.oauth.refresh_token(Connection._oauth2_token_url, client_id=connection.client_id,
+				token = connection.oauth.refresdh_token(Connection._oauth2_token_url, client_id=connection.client_id,
 													   client_secret=connection.client_secret)
 				log.info('New token fetched')
 				save_token(token)

--- a/O365/connection.py
+++ b/O365/connection.py
@@ -82,6 +82,7 @@ def delete_token(token_path=None):
 class Connection(with_metaclass(Singleton)):
 	_oauth2_authorize_url = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
 	_oauth2_token_url = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+	default_headers = None
 
 	def __init__(self):
 		""" Creates a O365 connection object """
@@ -196,6 +197,8 @@ class Connection(with_metaclass(Singleton)):
 		con_params = {}
 		if connection.proxy_dict:
 			con_params['proxies'] = connection.proxy_dict
+		if connection.default_headers:
+			con_params['headers'] = connection.default_headers
 		con_params.update(kwargs)
 
 		log.info('Requesting URL: {}'.format(request_url))


### PR DESCRIPTION
Have values of type dict returned also be converted to type MicroDict. 

Things like getSenderEmail where failing for me because emailAddress started with a lowercase e and the first key lookup returned a normal dict without the MicroDict ability to ignore case of the initial letter.

For reference this failed because of 'EmailAddress' instead of 'emailAddress' for me.
	def getSenderEmail(self):
		'''get the email address of the sender.'''
		return self.json['Sender']['EmailAddress']['Address']

New class proposed:
class MicroDict(dict):
	def __getitem__(self, key):
		result = super(MicroDict, self).get(key[:1].lower() + key[1:], None)
		if result is None:
			result = super(MicroDict, self).get(key[:1].upper() + key[1:])
		if type(result) is dict:
			result = MicroDict(result)
		return result
