### PR TITLE
Have values of type dict returned also be converted to type MicroDict.

### DIFF
--- a/O365/connection.py
+++ b/O365/connection.py
@@ -17,6 +17,8 @@ class MicroDict(dict):
 		result = super(MicroDict, self).get(key[:1].lower() + key[1:], None)
 		if result is None:
 			result = super(MicroDict, self).get(key[:1].upper() + key[1:])
+		if type(result) is dict:
+			result = MicroDict(result)
 		return result
 
 


### PR DESCRIPTION
This will ensure that results returned are always of never of type dict and instead are of type MicroDict.

I ran into an issue using getSenderEmail where 'EmailAddress' failed because the dict would not recognize the element 'emailAddress' as the same. By converting dict's to MicroDict's this method works for me again. 