### PR TITLE
Use oauth in message calls

### DIFF
--- a/O365/fluent_inbox.py
+++ b/O365/fluent_inbox.py
@@ -205,9 +205,10 @@ class FluentInbox(object):
 										   params=params)
 		self.fetched_count += count
 
+		connection = Connection()
 		messages = []
 		for message in response:
-			messages.append(Message(message, Connection().auth))
+			messages.append(Message(message, connection.auth, oauth=connection.oauth))
 
 		return messages
 


### PR DESCRIPTION
Save oauth in message for later use.
Messages now use oauth if it's been set.
Use response.ok to determine if call succeeded.
Changed Content-type to Content-Type.

Response doc: http://docs.python-requests.org/en/master/api/#requests.Response