### PR TITLE
Correcting CalendarColors names

### DIFF
--- a/O365/calendar.py
+++ b/O365/calendar.py
@@ -50,17 +50,18 @@ class EventShowAs(Enum):
 
 
 class CalendarColors(Enum):
-    LightBlue = 0
-    LightGreen = 1
-    LightOrange = 2
-    LightGray = 3
-    LightYellow = 4
-    LightTeal = 5
-    LightPink = 6
-    LightBrown = 7
-    LightRed = 8
-    MaxColor = 9
-    Auto = -1
+    LightBlue = 'lightBlue'
+    LightGreen = 'lightGreen'
+    LightOrange = 'lightOrange'
+    LightGray = 'lightGray'
+    LightYellow = 'lightYellow'
+    LightTeal = 'lightTeal'
+    LightPink = 'lightPink'
+    LightBrown = 'lightBrown'
+    LightRed = 'lightRed'
+    MaxColor = 'maxColor'
+    Auto = 'auto'
+
 
 
 class EventType(Enum):
@@ -1494,20 +1495,11 @@ class Calendar(ApiComponent, HandleRecipientsMixin):
         self.calendar_id = cloud_data.get(self._cc('id'), None)
         self.__owner = self._recipient_from_cloud(
             cloud_data.get(self._cc('owner'), {}), field='owner')
-        color = cloud_data.get(self._cc('color'), -1)
-        if isinstance(color, str):
-            color = 0 if color == 'lightBlue' else color
-            color = 1 if color == 'lightGreen' else color
-            color = 2 if color == 'lightOrange' else color
-            color = 3 if color == 'lightGray' else color
-            color = 4 if color == 'lightYellow' else color
-            color = 5 if color == 'lightTeal' else color
-            color = 6 if color == 'lightPink' else color
-            color = 7 if color == 'lightBrown' else color
-            color = 8 if color == 'lightRed' else color
-            color = 9 if color == 'maxColor' else color
-            color = -1 if color == 'auto' else color
-        self.color = CalendarColors(color)
+        color = cloud_data.get(self._cc('color'), 'auto')
+        try:
+            self.color = CalendarColors(color)
+        except:
+            self.color = CalendarColors('auto')
         self.can_edit = cloud_data.get(self._cc('canEdit'), False)
         self.can_share = cloud_data.get(self._cc('canShare'), False)
         self.can_view_private_items = cloud_data.get(

--- a/O365/calendar.py
+++ b/O365/calendar.py
@@ -50,17 +50,17 @@ class EventShowAs(Enum):
 
 
 class CalendarColors(Enum):
-    lightBlue = 0
-    lightGreen = 1
-    lightOrange = 2
-    lightGray = 3
-    lightYellow = 4
-    lightTeal = 5
-    lightPink = 6
-    lightBrown = 7
-    lightRed = 8
-    maxColor = 9
-    auto = -1
+    LightBlue = 0
+    LightGreen = 1
+    LightOrange = 2
+    LightGray = 3
+    LightYellow = 4
+    LightTeal = 5
+    LightPink = 6
+    LightBrown = 7
+    LightRed = 8
+    MaxColor = 9
+    Auto = -1
 
 
 class EventType(Enum):
@@ -1496,8 +1496,17 @@ class Calendar(ApiComponent, HandleRecipientsMixin):
             cloud_data.get(self._cc('owner'), {}), field='owner')
         color = cloud_data.get(self._cc('color'), -1)
         if isinstance(color, str):
+            color = 0 if color == 'lightBlue' else color
+            color = 1 if color == 'lightGreen' else color
+            color = 2 if color == 'lightOrange' else color
+            color = 3 if color == 'lightGray' else color
+            color = 4 if color == 'lightYellow' else color
+            color = 5 if color == 'lightTeal' else color
+            color = 6 if color == 'lightPink' else color
+            color = 7 if color == 'lightBrown' else color
+            color = 8 if color == 'lightRed' else color
+            color = 9 if color == 'maxColor' else color
             color = -1 if color == 'auto' else color
-            # TODO: other string colors?
         self.color = CalendarColors(color)
         self.can_edit = cloud_data.get(self._cc('canEdit'), False)
         self.can_share = cloud_data.get(self._cc('canShare'), False)

--- a/O365/calendar.py
+++ b/O365/calendar.py
@@ -50,17 +50,17 @@ class EventShowAs(Enum):
 
 
 class CalendarColors(Enum):
-    LightBlue = 0
-    LightGreen = 1
-    LightOrange = 2
-    LightGray = 3
-    LightYellow = 4
-    LightTeal = 5
-    LightPink = 6
-    LightBrown = 7
-    LightRed = 8
-    MaxColor = 9
-    Auto = -1
+    lightBlue = 0
+    lightGreen = 1
+    lightOrange = 2
+    lightGray = 3
+    lightYellow = 4
+    lightTeal = 5
+    lightPink = 6
+    lightBrown = 7
+    lightRed = 8
+    maxColor = 9
+    auto = -1
 
 
 class EventType(Enum):


### PR DESCRIPTION
The "CalendarColor" names seem to start with a small not a capital "L".
To keep a consistent namescheme "MaxColor" and "Auto" should be renamed to "maxColor" and "auto", too.
( In row 1499 it is already "auto")



I encountered this problem when my code throwed the following error while trying to get a calendar:

```
>>> schedule = account.schedule()
>>> calendar = schedule.get_calendar(calendar_name='Heizung')

ValueError: 'lightGreen' is not a valid CalendarColors


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<pyshell#9>", line 1, in <module>
    calendar = schedule.get_calendar(calendar_name='Heizung')
  File "E:\Programme\Python\Python3\lib\site-packages\O365\calendar.py", line 1849, in get_calendar
    **{self._cloud_data_key: data})
  File "E:\Programme\Python\Python3\lib\site-packages\O365\calendar.py", line 1501, in __init__
    self.color = CalendarColors(color)
  File "E:\Programme\Python\Python3\lib\enum.py", line 309, in __call__
    return cls.__new__(cls, value)
  File "E:\Programme\Python\Python3\lib\enum.py", line 561, in __new__
    raise exc
  File "E:\Programme\Python\Python3\lib\enum.py", line 545, in __new__
    result = cls._missing_(value)
  File "E:\Programme\Python\Python3\lib\enum.py", line 574, in _missing_
    raise ValueError("%r is not a valid %s" % (value, cls.__name__))
ValueError: 'lightGreen' is not a valid CalendarColors
```

I'm using a private outlook account (wich is accessed through "https://outlook.live.com/") by the way.
Buissnes / school accounts are accessed through "https://outlook.office365.com/owa/" (i can't log in there with my private account).
Maybe Microsoft has an inconsistent color name convention here (difference between private and buissnes).
This should be checked before merging my pull request.

This is my first Pull request by the way.
I hope Iam doing this right 🤓 