### PR TITLE
Ability to create, and edit listitems in sharepoint

### DIFF
--- a/O365/sharepoint.py
+++ b/O365/sharepoint.py
@@ -121,7 +121,8 @@ class SharepointList(ApiComponent):
     _endpoints = {
         'get_items': '/items',
         'get_item_by_id': '/items/{item_id}',
-        'get_list_columns': '/columns'
+        'get_list_columns': '/columns',
+        'update_list_item': '/items/{item_id}/fields'
     }
     list_item_constructor = SharepointListItem
     list_column_constructor = SharepointListColumn
@@ -250,13 +251,11 @@ class SharepointList(ApiComponent):
         :rtype: SharepointListItem
         """
         
-        url = self.build_url(self._endpoints.get('get_item_by_id').format(item_id=item_id) + '/fields')
+        url = self.build_url(self._endpoints.get('update_list_item').format(item_id=item_id))
         
         response = self.con.patch(url, update)
         
-        data = response.json()
-        
-        return self.get_item_by_id(item_id)
+        return bool(response)
 
     def create_list_item(self, new_data):
         """Create new list item
@@ -269,6 +268,8 @@ class SharepointList(ApiComponent):
         url = self.build_url(self._endpoints.get('get_items'))
         
         response = self.con.post(url, {'fields': new_data})
+        if not response:
+            return False
         
         data = response.json()
         


### PR DESCRIPTION
Took a stab on adding some functionality that I have working on my O365 sharepoint.  Open to feedback on any way to make this better, but figured it was a start.  Review at your leisure.

Added a crosswalk between display name, and internal name for user defined columns in the list.  Added update_list_item to update a given listitem, and create_list_item to create a new list item.

Additions:
1. SharepointList.column_name_cw - dictionary of {display_name: internal_name} for user defined columns in a sharepoint list. (I have found this useful when doing things like list updates, additions, and pulling down detail)

2. SharepointList.update_list_item(item_id, update) - given an item id and dict of {internal column name: updated data} it will update the sharepoint list item, and return the updated item.

3. SharepointList.create_list_item(new_data) - given a dict of {internal column name: new data} it will make a new item in the sharepoint list and return the new item as a SharepointListItem

Open to adding information to documentation as well, but wanted to get the code ironed out first.
Address and Closes #181 