### PR TITLE
Use just resource_prefix if parent is a site

### DIFF
--- a/O365/sharepoint.py
+++ b/O365/sharepoint.py
@@ -275,7 +275,8 @@ class Site(ApiComponent):
 
         # prefix with the current known site
         resource_prefix = 'sites/{site_id}'.format(site_id=self.object_id)
-        main_resource = '{}{}'.format(main_resource, resource_prefix)
+        main_resource = (resource_prefix if isinstance(parent,Site)
+                            else '{}{}'.format(main_resource, resource_prefix))
 
         super().__init__(
             protocol=parent.protocol if parent else kwargs.get('protocol'),


### PR DESCRIPTION
When the site class is being built from a parent site, in the cases of get_subsites, the parent main_resource does not need to be used, only the resource_prefix.

Closes #214 

Fix works when building a site directly from Sharepoint class and also from subsite class.  Functionality is as expected for the resulting site class no matter how it was built with this fix.