### PR TITLE
Fixes error message when doing calendar queries with MSOffice365Protocol

### DIFF
--- a/O365/calendar.py
+++ b/O365/calendar.py
@@ -1614,10 +1614,10 @@ class Calendar(ApiComponent, HandleRecipientsMixin):
                     # and the 3rd position in filter_data contains the value
                     word = query_data[2][3]
 
-                    if attribute.startswith('start/'):
+                    if attribute.lower().startswith('start/'):
                         start = word.replace("'", '')  # remove the quotes
                         query.remove_filter('start')
-                    if attribute.startswith('end/'):
+                    if attribute.lower().startswith('end/'):
                         end = word.replace("'", '')  # remove the quotes
                         query.remove_filter('end')
 


### PR DESCRIPTION
When using the MSOffice365Protocol, a calendar.get_events() query fails with:
`ValueError: When 'include_recurring' is True you must provide a 'start' and
 'end' datetimes inside a Query instance.` even when such a query is provided.

This is due to the fact the the case of the Filter is not the same between
protocols, and the code was assuming that some filters were in lower case.

Fixes #226 