### PR TITLE
fix bug for removing all categories from a message

### DIFF
--- a/O365/message.py
+++ b/O365/message.py
@@ -546,7 +546,7 @@ class Message(ApiComponent, AttachableMixin, HandleRecipientsMixin):
         if self.sender and self.sender.address:
             message[cc('from')] = self._recipient_to_cloud(self.sender)
 
-        if self.categories:
+        if self.categories or 'categories' in restrict_keys:
             message[cc('categories')] = self.categories
 
         if self.object_id and not self.__is_draft:


### PR DESCRIPTION
`to_api_data()` will not serialize the `self.categories` property if you try to remove all categories from a message since `self.categories` evaluates to `False` for an empty list.

If `self.categories` has been modified, the `categories` string will be passed into `to_api_data()` from the `save_message()` function as the `restrict_keys` parameters.