### PR TITLE
Set chunk_size to a valid value ('auto' is not a valid value in reque…

### DIFF
--- a/O365/drive.py
+++ b/O365/drive.py
@@ -73,6 +73,7 @@ class DownloadableMixin:
                     stream = True
                 else:
                     stream = False
+                chunk_size = None
             elif isinstance(chunk_size, int):
                 stream = True
             else:


### PR DESCRIPTION
…sts)

If `chunk_size` is set to `'auto'` and the file is bigger than the chunk size, the method fails because the value `'auto'` is not of type `int` or `None`.

see [Response.iter_content()](https://2.python-requests.org/en/master/api/#requests.Response.iter_content)