### PR TITLE
Fix error when flag does not have start and due date

### DIFF
--- a/O365/message.py
+++ b/O365/message.py
@@ -149,8 +149,8 @@ class MessageFlag(ApiComponent):
             self._cc('flagStatus'): self._cc(self.__status.value)
         }
         if self.__status is Flag.Flagged:
-            data[self._cc('startDateTime')] = self._build_date_time_time_zone(self.__start)
-            data[self._cc('dueDateTime')] = self._build_date_time_time_zone(self.__due_date)
+            data[self._cc('startDateTime')] = self._build_date_time_time_zone(self.__start) if self.__start is not None else None
+            data[self._cc('dueDateTime')] = self._build_date_time_time_zone(self.__due_date) if self.__due_date is not None else None
 
         if self.__status is Flag.Complete:
             data[self._cc('completedDateTime')] = self._build_date_time_time_zone(self.__completed)


### PR DESCRIPTION
This was throwing error when it was parsing flagged messages with no start and due date.
