### PR TITLE
Fix Table Delete Row method to match alternative docs

### DIFF
--- a/O365/excel.py
+++ b/O365/excel.py
@@ -1131,7 +1131,7 @@ class Table(ApiComponent):
         'add_column': '/columns/add',
         'get_rows': '/rows',
         'get_row': '/rows/{id}',
-        'delete_row': '/rows/{id}/delete',
+        'delete_row': '/rows/$/itemAt(index={id})',
         'get_row_index': '/rows/itemAt',
         'add_rows': '/rows/add',
         'delete': '/delete',
@@ -1333,7 +1333,7 @@ class Table(ApiComponent):
         :return bool: Success or Failure
         """
         url = self.build_url(self._endpoints.get('delete_row').format(id=index))
-        return bool(self.session.post(url))
+        return bool(self.session.delete(url))
 
     def add_rows(self, values=None, index=None):
         """


### PR DESCRIPTION
See the following thread: https://github.com/microsoftgraph/microsoft-graph-docs/issues/4818
The current table row deletion doesn't work and returns the following "Error Message: Resource not found for the segment 'delete'."

The API method here does work: 
https://docs.microsoft.com/en-us/graph/api/resources/excel?view=graph-rest-beta#delete-table-row
I've updated the code and it now works. 