### PR TITLE
Update table delete to match alternate in docs

### DIFF
--- a/O365/excel.py
+++ b/O365/excel.py
@@ -1134,7 +1134,7 @@ class Table(ApiComponent):
         'delete_row': '/rows/$/itemAt(index={id})',
         'get_row_index': '/rows/itemAt',
         'add_rows': '/rows/add',
-        'delete': '/delete',
+        'delete': '/',
         'data_body_range': '/dataBodyRange',
         'header_row_range': '/headerRowRange',
         'total_row_range': '/totalRowRange',
@@ -1400,7 +1400,7 @@ class Table(ApiComponent):
     def delete(self):
         """ Deletes this table """
         url = self.build_url(self._endpoints.get('delete'))
-        return bool(self.session.post(url))
+        return bool(self.session.delete(url))
 
     def _get_range(self, endpoint_name):
         """ Returns a Range based on the endpoint name """


### PR DESCRIPTION
Similar to my fix to delete rows, I have another fix for deleting tables 
See: https://github.com/microsoftgraph/microsoft-graph-docs/issues/4188
Using the Post for deleting doesn't work (POST /workbook/tables/{id|name}/delete
) but using the Delete method (DELETE /workbook/worksheets/{id|name}/tables/{id|name}) does work

