### PR TITLE
Bugfix

### DIFF
--- a/O365/directory.py
+++ b/O365/directory.py
@@ -189,7 +189,7 @@ class User(ApiComponent):
 class Directory(ApiComponent):
 
     _endpoints = {
-        'get_user': '/{email}'
+        'get_user': '/{}'
     }
     user_constructor = User
 


### PR DESCRIPTION
- parameter can be email or user id, so it should not be named
- the build_url call provides an unnamed parameter. This led to the following error: 

```
File "/home/xxx/.local/lib/python3.7/site-packages/O365/directory.py", line 261, in get_user
    url = self.build_url(self._endpoints.get('get_user').format(user))
KeyError: 'email'
```