### PR TITLE
add new LockableFileSystemTokenBackend example

### DIFF
--- a/O365/utils/token.py
+++ b/O365/utils/token.py
@@ -225,13 +225,7 @@ class FileSystemTokenBackend(BaseTokenBackend):
         """
         return self.token_path.exists()
 
-<<<<<<< HEAD
-=======
-    def should_refresh_token(self, con=None):
-        return not self.fs_wait
 
-
->>>>>>> 1e0da3b1019df592718115a0f08af219e7a8f061
 class FirestoreBackend(BaseTokenBackend):
     """ A Google Firestore database backend to store tokens """
 

--- a/O365/utils/token.py
+++ b/O365/utils/token.py
@@ -172,9 +172,6 @@ class FileSystemTokenBackend(BaseTokenBackend):
         else:
             token_filename = token_filename or 'o365_token.txt'
             self.token_path = token_path / token_filename
-        
-        # is this backend waiting on the filesystem
-        self.fs_wait = False
 
     def __repr__(self):
         return str(self.token_path)
@@ -227,9 +224,6 @@ class FileSystemTokenBackend(BaseTokenBackend):
         :return bool: True if exists, False otherwise
         """
         return self.token_path.exists()
-
-    def should_refresh_token(self):
-        return not self.fs_wait
 
 class FirestoreBackend(BaseTokenBackend):
     """ A Google Firestore database backend to store tokens """

--- a/examples/token_backends.py
+++ b/examples/token_backends.py
@@ -120,14 +120,14 @@ class LockableFileSystemTokenBackend(FileSystemTokenBackend):
         the token and its file, or if another Connection instance has already 
         updated it and we should just load that updated token from the file.
 
-        It will always return False, OR raise an error if a locked token file
+        It will always return False, None, OR raise an error if a token file
         couldn't be accessed after X tries. That is because this method 
         completely handles token refreshing via the passed Connection object 
         argument. If it determines that the token should be refreshed, it locks
         the token file, calls the Connection's 'refresh_token' method (which 
         loads the fresh token from the server into memory and the file), then 
         unlocks the file. Since refreshing has been taken care of, the calling 
-        method does not need to refresh and we return False.
+        method does not need to refresh and we return None.
         
         If we are blocked because the file is locked, that means another 
         instance is using it. We'll change the backend's state to waiting,
@@ -136,7 +136,7 @@ class LockableFileSystemTokenBackend(FileSystemTokenBackend):
         loop again.
         
         If this newly loaded token is not expired, the other instance loaded
-        a new token to file, and we can happily move on. Again, return False 
+        a new token to file, and we can happily move on and return False.
         (since we don't need to refresh the token anymore). If the same token 
         was loaded into memory again and is still expired, that means it wasn't
         updated by the other instance yet. Try accessing the file again for X 


### PR DESCRIPTION
I've written this subclass example to work with your recent changes in the `Connection` class. This example works quite nicely, and successfully places all locking logic in the back end. Take a look and see what you think.

I also decided to remove `fs_wait` from the `FileSystemTokenBackend` - it didn't really make sense to have it there since that class will never be used in the scope of locking...it will always be subclassed, which is the more appropriate place for that attribute.

I'm not even sure it's really needed in the subclass - but I decided to leave it as maybe it could be helpful to be able to know the backend's "waiting" state.