### PR TITLE
FirestoreBackend: Replace client.collections() with collection()

### DIFF
--- a/O365/utils/token.py
+++ b/O365/utils/token.py
@@ -241,7 +241,7 @@ class FirestoreBackend(BaseTokenBackend):
         self.client = client
         self.collection = collection
         self.doc_id = doc_id
-        self.doc_ref = client.collections(collection).document(doc_id)
+        self.doc_ref = client.collection(collection).document(doc_id)
         self.field_name = field_name
 
     def __repr__(self):


### PR DESCRIPTION
Firestore client's collections() method doesn't take parameter
anymore. The collections() method can be replaced with collection
('collection_name') to get the required collection. Therefore,
fix this issue by replacing client.collections('collection_name')
with client.collection('collection_name') in the __init__ method
of FirestoreBackend.