### PR TITLE
Improve convert_to_pdf integration

### DIFF
--- a/O365/drive.py
+++ b/O365/drive.py
@@ -81,8 +81,11 @@ class DownloadableMixin:
                                  "or any integer number representing bytes")
 
             params = {}
-            if convert_to_pdf and Path(name).suffix in ALLOWED_PDF_EXTENSIONS:
-                params['format'] = 'pdf'
+            if convert_to_pdf:
+                if Path(self.name).suffix in ALLOWED_PDF_EXTENSIONS:
+                    params['format'] = 'pdf'
+                else:
+                    raise ValueError("File is not included in 'ALLOWED_PDF_EXTENSIONS'")
 
             with self.con.get(url, stream=stream, params=params) as response:
                 if not response:


### PR DESCRIPTION
A small proposal to include a validation to convert_to_pdf:

- Raise ValueError if wrong file extension is given

- Make file extension validation on original file (`self.name`) and not on target file (`name`)

Especially, the last point gave me short headache since my target file name was obviously `name.pdf`, while `,pdf` is not included in the allowed extensions.

Hope it helps!

Best
Leander