### PR TITLE
Fix no content on stream download

### DIFF
--- a/O365/drive.py
+++ b/O365/drive.py
@@ -93,20 +93,20 @@ class DownloadableMixin:
                         response.reason))
                     return False
 
-            def write_output(out):
-                if stream:
-                    for chunk in response.iter_content(
-                            chunk_size=chunk_size):
-                        if chunk:
-                            out.write(chunk)
-                else:
-                    out.write(response.content)
+                def write_output(out):
+                    if stream:
+                        for chunk in response.iter_content(
+                                chunk_size=chunk_size):
+                            if chunk:
+                                out.write(chunk)
+                    else:
+                        out.write(response.content)
 
-            if output:
-                write_output(output)
-            else:
-                with to_path.open(mode='wb') as output:
+                if output:
                     write_output(output)
+                else:
+                    with to_path.open(mode='wb') as output:
+                        write_output(output)
 
         except Exception as e:
             log.error(


### PR DESCRIPTION
Fixed indentation bug from #468 causing downloads of files with the `stream=True` to write no content.
Must be included in the same release as #468.