### PR TITLE
Fix for running calculations when using sessions

### DIFF
--- a/O365/excel.py
+++ b/O365/excel.py
@@ -1712,6 +1712,9 @@ class WorkbookApplication(ApiComponent):
         data = {"calculationType": calculation_type}
         headers = {"Content-type": "application/json"}
 
+        if(self.parent.session.session_id):
+            headers['workbook-session-id'] = self.parent.session.session_id
+
         response = self.con.post(url, headers=headers, data=data)
         if not response:
             return False


### PR DESCRIPTION
If running excel workbook in session mode, running the calculations should be done for the current session.

Without this fix, the API call is successful but it will not refresh any calculations for the sessions, so the session being worked on will never get recalculated.