### PR TITLE
Add Task.importance and Task.is_starred properties

### DIFF
--- a/O365/tasks.py
+++ b/O365/tasks.py
@@ -167,7 +167,7 @@ class Task(ApiComponent):
 
     @property
     def importance(self):
-        """ Task importance
+        """ Task importance (Low, Normal, High)
 
         :getter: Get importance level
         :type: str
@@ -176,9 +176,9 @@ class Task(ApiComponent):
 
     @property
     def is_starred(self):
-        """ Task importance
+        """ Is the task starred (high importance)
 
-        :getter: Get importance level
+        :getter: Check if importance is high
         :type: str
         """
         return self.__importance == "High"

--- a/O365/tasks.py
+++ b/O365/tasks.py
@@ -181,7 +181,7 @@ class Task(ApiComponent):
         :getter: Check if importance is high
         :type: bool
         """
-        return self.__importance == "High"
+        return self.__importance.casefold() == "High".casefold()
 
 
     @body.setter

--- a/O365/tasks.py
+++ b/O365/tasks.py
@@ -179,7 +179,7 @@ class Task(ApiComponent):
         """ Is the task starred (high importance)
 
         :getter: Check if importance is high
-        :type: str
+        :type: bool
         """
         return self.__importance == "High"
 

--- a/O365/tasks.py
+++ b/O365/tasks.py
@@ -69,7 +69,8 @@ class Task(ApiComponent):
         self.__modified = cloud_data.get(cc('lastModifiedDateTime'), None)
         self.__status = cloud_data.get(cc('status'), None)
         self.__is_completed = self.__status == 'Completed'
-
+        self.__importance = cloud_data.get(cc('importance'), None)
+        
         local_tz = self.protocol.timezone
         self.__created = parse(self.__created).astimezone(
             local_tz) if self.__created else None
@@ -163,6 +164,25 @@ class Task(ApiComponent):
         :type: str
         """
         return self.__body
+
+    @property
+    def importance(self):
+        """ Task importance
+
+        :getter: Get importance level
+        :type: str
+        """
+        return self.__importance
+
+    @property
+    def is_starred(self):
+        """ Task importance
+
+        :getter: Get importance level
+        :type: str
+        """
+        return self.__importance == "High"
+
 
     @body.setter
     def body(self, value):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = '2.0.13'
+VERSION = '2.0.14'
 
 # Available classifiers: https://pypi.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = '2.0.14'
+VERSION = '2.0.13'
 
 # Available classifiers: https://pypi.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
This PR adds a read-only `importance` property as per https://docs.microsoft.com/en-us/graph/api/resources/todotask?view=graph-rest-1.0#properties

Also, an experimentally established level "High" was found to match the MS To Do task when starred, and `is_starred` implements this heuristic.