### PR TITLE
Fix bug: download_contents function does not create subfolder if it has no child.

### DIFF
--- a/O365/drive.py
+++ b/O365/drive.py
@@ -1146,8 +1146,10 @@ class Folder(DriveItem):
             if item.is_folder and item.child_count > 0:
                 item.download_contents(to_folder=to_folder / item.name)
             elif item.is_folder and item.child_count == 0:
-                if not to_folder.exists():
-                    to_folder.mkdir()
+                # Create child folder without contents.
+                child_folder = to_folder / item.name
+                if not child_folder.exists():
+                    child_folder.mkdir()
             else:
                 item.download(to_folder)
 


### PR DESCRIPTION
# Issue
Thanks for your great work!
I used this library for a while and found a bug in drive client. Its `download_contents` does nothing for its child empty folder.

https://github.com/O365/python-o365/blob/master/O365/drive.py#L1145-L1150
```python
        for item in self.get_items(query=self.new_query().select('id', 'size', 'folder', 'name')):
            if item.is_folder and item.child_count > 0:
                item.download_contents(to_folder=to_folder / item.name)
            elif item.is_folder and item.child_count == 0:
                if not to_folder.exists(): # <---- This line wants to create child folder of `item`, not `to_folder`
                    to_folder.mkdir()
            else:
                item.download(to_folder)
```