### PR TITLE
Add support for list item fields

### DIFF
--- a/O365/sharepoint.py
+++ b/O365/sharepoint.py
@@ -258,8 +258,23 @@ class SharepointList(ApiComponent):
 
     def __eq__(self, other):
         return self.object_id == other.object_id
-
-    def get_items(self, limit=None, *, query=None, order_by=None, batch=None):
+    
+    def build_field_filter(self, expand_fields):
+        if expand_fields == True:
+            return 'fields'
+        elif isinstance(expand_fields, list):
+            result = ''
+            for field in expand_fields:
+                if field in self.column_name_cw.values():
+                    result += field + ','         
+                elif field in self.column_name_cw:
+                    result += self.column_name_cw[field] + ','
+                else:
+                    log.warning('"{}" is not a valid field name - check case'.format(field))
+            if result != '':
+                return 'fields(select=' + result.rstrip(',') + ')'
+            
+    def get_items(self, limit=None, *, query=None, order_by=None, batch=None, expand_fields=None):
         """ Returns a collection of Sharepoint Items
         :param int limit: max no. of items to get. Over 999 uses batch.
         :param query: applies a filter to the request.
@@ -268,6 +283,9 @@ class SharepointList(ApiComponent):
         :type order_by: Query or str
         :param int batch: batch size, retrieves items in
          batches allowing to retrieve more items than the limit.
+        :param expand_fields: specify user-defined fields to return,
+         True will return all fields
+        :type expand_fields: list or bool         
         :return: list of Sharepoint Items
         :rtype: list[SharepointListItem] or Pagination
         """
@@ -279,6 +297,9 @@ class SharepointList(ApiComponent):
 
         params = {'$top': batch if batch else limit}
 
+        if expand_fields is not None:
+            params['expand'] = self.build_field_filter(expand_fields)
+            
         if order_by:
             params['$orderby'] = order_by
 
@@ -305,12 +326,24 @@ class SharepointList(ApiComponent):
         else:
             return items
 
-    def get_item_by_id(self, item_id):
-        """ Returns a sharepoint list item based on id"""
+    def get_item_by_id(self, item_id, expand_fields=None):
+        """ Returns a sharepoint list item based on id
+        :param int item_id: item id to search for
+        :param expand_fields: specify user-defined fields to return,
+         True will return all fields
+        :type expand_fields: list or bool         
+        :return: Sharepoint Item
+        :rtype: SharepointListItem
+        """
 
         url = self.build_url(self._endpoints.get('get_item_by_id').format(item_id=item_id))
-
-        response = self.con.get(url)
+        
+        params = {}
+        
+        if expand_fields is not None:
+            params['expand'] = self.build_field_filter(expand_fields)
+            
+        response = self.con.get(url, params=params)
 
         if not response:
             return []


### PR DESCRIPTION
* Added build_field_filter helper function that will add fields to the query based on their internal name or display name
* Added expand_fields argument to get_items and get_item_by_id methods, if you pass True it will return all fields, if you pass a list of field names, it will filter as such