### PR TITLE
issue #584: Remove python 3.5 from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '3.5'
 - '3.6'
 install:
 - pip install -r requirements-dev.txt

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     long_description=read('README.md'),
     long_description_content_type="text/markdown",
     classifiers=CLASSIFIERS,
-    python_requires=">=3.4",
+    python_requires=">=3.6",
     install_requires=requires,
 )


### PR DESCRIPTION
The code uses f-strings which aren't supported till 3.6  .

Along the way I also changed the minimum python version in the setup.py file to be python 3.6

Tested by setting up my own travis in github, and ran it.