### PR TITLE
Update connection.py

### DIFF
--- a/O365/connection.py
+++ b/O365/connection.py
@@ -365,6 +365,8 @@ class Connection:
          (client_id, client_secret)
         """
         if auth_flow_type == 'public':  # allow client id only for public flow
+            if isinstance(credentials, str): 
+                credentials = (credentials,)
             if not isinstance(credentials, tuple) or len(credentials) != 1 or (not credentials[0]):
                 raise ValueError('Provide client id only for public flow credentials')
         else:


### PR DESCRIPTION
I have found that I couldn't assign a single value tuple without a trailing comma. If credentials is provided as `(app_id)` it ends up being turned in to a str (~~even if you explicitly cast it as a tuple~~ edit: this actually splits the string in to a tuple of it's chars) thus failing the tuple instance check. If you use `(app_id,)` everything works.

I added a check that will ensure it is a single value tuple by converting string to tuple (using the necessary trailing comma).