### PR TITLE
Fix for status code: 429 - Too many requests.

### DIFF
--- a/O365/connection.py
+++ b/O365/connection.py
@@ -585,7 +585,8 @@ class Connection:
             retry = Retry(total=self.request_retries, read=self.request_retries,
                           connect=self.request_retries,
                           backoff_factor=RETRIES_BACKOFF_FACTOR,
-                          status_forcelist=RETRIES_STATUS_LIST)
+                          status_forcelist=RETRIES_STATUS_LIST,
+                          respect_retry_after_header=True)
             adapter = HTTPAdapter(max_retries=retry)
             session.mount('http://', adapter)
             session.mount('https://', adapter)


### PR DESCRIPTION
The other day I have doing bulk operations via Graph API. My code is utilizing  python async with Multi process to achieve maximum speed. I occasionally run into the above mentioned issue and entire process would halt. 