### PR TITLE
Allow a dynamic consent process using functions

### DIFF
--- a/O365/account.py
+++ b/O365/account.py
@@ -1,5 +1,5 @@
 from .connection import Connection, Protocol, MSGraphProtocol, MSOffice365Protocol
-from .utils import ME_RESOURCE
+from .utils import ME_RESOURCE, consent
 
 
 class Account:
@@ -69,7 +69,7 @@ class Account:
 
         return token is not None and not token.is_expired
 
-    def authenticate(self, *, scopes=None, **kwargs):
+    def authenticate(self, *, scopes=None, handle_consent=consent.consent_input_token, **kwargs):
         """ Performs the oauth authentication flow using the console resulting in a stored token.
         It uses the credentials passed on instantiation
 
@@ -92,10 +92,7 @@ class Account:
 
             consent_url, _ = self.con.get_authorization_url(**kwargs)
 
-            print('Visit the following url to give consent:')
-            print(consent_url)
-
-            token_url = input('Paste the authenticated url here:\n')
+            token_url = handle_consent(consent_url)
 
             if token_url:
                 result = self.con.request_token(token_url, **kwargs)  # no need to pass state as the session is the same

--- a/O365/utils/__init__.py
+++ b/O365/utils/__init__.py
@@ -6,3 +6,4 @@ from .utils import NEXT_LINK_KEYWORD, ME_RESOURCE, USERS_RESOURCE
 from .utils import OneDriveWellKnowFolderNames, Pagination, Query
 from .token import BaseTokenBackend, Token, FileSystemTokenBackend, FirestoreBackend, AWSS3Backend, AWSSecretsBackend
 from .windows_tz import IANA_TO_WIN, WIN_TO_IANA
+from . import consent

--- a/O365/utils/consent.py
+++ b/O365/utils/consent.py
@@ -1,0 +1,5 @@
+def consent_input_token(consent_url):
+    print('Visit the following url to give consent:')
+    print(consent_url)
+
+    return input('Paste the authenticated url here:\n')


### PR DESCRIPTION
This paves the way for more elegant alternatives for attaining a token using a consent URL. Example implementations would not be limited to using a web browser, a pyperclip copy, or a web browser combined with a custom redirect_uri and a temporary HTTP server on localhost.
The default and current consent process function is O365.utils.consent.consent_input_token.