### PR TITLE
Use batch argument even when limit is huge

### DIFF
--- a/O365/mailbox.py
+++ b/O365/mailbox.py
@@ -195,7 +195,7 @@ class Folder(ApiComponent):
             url = self.build_url(self._endpoints.get('folder_messages').format(
                 id=self.folder_id))
 
-        if limit is None or limit > self.protocol.max_top_value:
+        if not batch and (limit is None or limit > self.protocol.max_top_value):
             batch = self.protocol.max_top_value
 
         params = {'$top': batch if batch else limit}


### PR DESCRIPTION
If a query has a limit which is bigger than the protocol's max_top_value than it only makes sense to batch it, and even more let the programmer decide the batch size.

Hope it doesn't break anything but it seems to me that if a batch argument can work with `limit = max_top_value  - 1` than it should also work with  `limit = max_top_value  + 1` .

Resolves #622