### PR TITLE
Fix for drive copy operation

### DIFF
--- a/O365/drive.py
+++ b/O365/drive.py
@@ -774,7 +774,7 @@ class DriveItem(ApiComponent):
         # Find out if the server has run a Sync or Async operation
         location = response.headers.get('Location', None)
 
-        if 'monitor' in location:
+        if response.status_code == 202:
             # Async operation
             return CopyOperation(parent=self.drive, monitor_url=location)
         else:


### PR DESCRIPTION
Starting today I started getting errors that looked like this:

```
    copied_excel_file = operation.get_item()
  File "/usr/local/lib/python3.7/site-packages/O365/drive.py", line 211, in get_item
    self.item_id) if self.item_id is not None else None
  File "/usr/local/lib/python3.7/site-packages/O365/drive.py", line 1599, in get_item
    response = self.con.get(url)
  File "/usr/local/lib/python3.7/site-packages/O365/connection.py", line 805, in get
    return self.oauth_request(url, 'get', params=params, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/O365/connection.py", line 794, in oauth_request
    return self._internal_request(self.session, url, method, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/O365/connection.py", line 756, in _internal_request
    raise HTTPError('{} | Error Message: {}'.format(e.args[0], error_message), response=response) from None
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://graph.microsoft.com/v1.0/me/drive/items/75ab69f0-09e7-4c27-b6d6-34a2eb7036ed | Error Message: The resource could not be found.
```

I traced it back to receiving a response to the copy operation where the location did not have `monitor` in the URL. In my case it the location was:
```
https://company.sharepoint.com/personal/directory/_api/v2.1/drive/operations/<OPERATION-UUID>?c=UkUvWHA...
```

When checking the contents of the Location URL it is exactly what I expect from the monitor URL. It contains:

```
{
    "percentageComplete": 100.0,
    "resourceId": "<RESOURCE ID>",
    "status": "completed"
}
```


When reading the [documentation here](https://docs.microsoft.com/en-us/graph/long-running-actions-overview?tabs=http) I found a bit that says:

> Note: The location URL returned may not be on the Microsoft Graph API endpoint.

This change has fixed the issue for me. The assumption is a `status_code` of 202 Accepted indicates the operation has been accepted so we should use the monitoring operation. 

When reading about the [copy operation here](https://docs.microsoft.com/en-us/graph/api/driveitem-copy?view=graph-rest-1.0&tabs=http) it doesn't really describe the synchronous case.

