### PR TITLE
Add OneNote support

### DIFF
--- a/O365/account.py
+++ b/O365/account.py
@@ -150,6 +150,17 @@ class Account:
         from .mailbox import MailBox
         return MailBox(parent=self, main_resource=resource, name='MailBox')
 
+    def notes(self, resource=None):
+        """ Get an instance to the notes for the specified account resource
+
+        :param str resource: Custom resource to be used in this mailbox
+         (Defaults to parent main_resource)
+        :return: a representation of account mailbox
+        :rtype: O365.mailbox.MailBox
+        """
+        from .notes import Notes
+        return Notes(parent=self, main_resource=resource, name='Notes')
+
     def address_book(self, *, resource=None, address_book='personal'):
         """ Get an instance to the specified address book for the
         specified account resource

--- a/O365/account.py
+++ b/O365/account.py
@@ -153,10 +153,10 @@ class Account:
     def notes(self, resource=None):
         """ Get an instance to the notes for the specified account resource
 
-        :param str resource: Custom resource to be used in this mailbox
+        :param str resource: Custom resource to be used for notes
          (Defaults to parent main_resource)
-        :return: a representation of account mailbox
-        :rtype: O365.mailbox.MailBox
+        :return: a representation of account notes
+        :rtype: O365.notes.Notes
         """
         from .notes import Notes
         return Notes(parent=self, main_resource=resource, name='Notes')

--- a/O365/notes.py
+++ b/O365/notes.py
@@ -1,5 +1,7 @@
 import logging
 
+from dateutil.parser import parse
+
 from .utils import ApiComponent
 from .utils import Pagination, NEXT_LINK_KEYWORD
 
@@ -29,7 +31,16 @@ class Page(ApiComponent):
         self.object_id = cloud_data.get(cc('id'), kwargs.get('object_id', None))
         self.created = cloud_data.get(cc('createdDateTime'), None)
         self.modified = cloud_data.get(cc('lastModifiedDateTime'), None)
-        self.title = cloud_data.get(self._cc('title'), '')
+
+        local_tz = self.protocol.timezone
+        self.created = parse(self.created).astimezone(
+            local_tz) if self.created else None
+        self.modified = parse(self.modified).astimezone(
+            local_tz) if self.modified else None
+
+        self.title = cloud_data.get(cc('title'), '')
+        self.web_link = cloud_data.get(cc('links'), {}).get(cc('oneNoteWebUrl'), {}).get(cc('href'), '')
+        self.onenote_link = cloud_data.get(cc('links'), {}).get(cc('oneNoteClientUrl'), {}).get(cc('href'), '')
         self.__content = None
 
     def __str__(self):

--- a/O365/notes.py
+++ b/O365/notes.py
@@ -136,7 +136,8 @@ class Notes(ApiComponent):
     """ A Microsoft OneNote"""
 
     _endpoints = {
-        'notes': '/onenote/notebooks'
+        'root_notebooks': '/onenote/notebooks',
+        'get_notebook': '/onenote/notebooks/{id}'
     }
     notebook_constructor = NoteBook
 
@@ -154,8 +155,8 @@ class Notes(ApiComponent):
             protocol=parent.protocol if parent else kwargs.get('protocol'),
             main_resource=main_resource)
 
-    def get_notebooks(self):
-        url = self.build_url(self._endpoints.get('notes'))
+    def list_notebooks(self):
+        url = self.build_url(self._endpoints.get('root_notebooks'))
 
         response = self.con.get(url)
 
@@ -167,3 +168,27 @@ class Notes(ApiComponent):
             for notebook in data.get('value', []))
 
         return notes
+
+    def get_notebook(self, notebook_id=None):
+        """ Returns a notebook by it's id
+
+        :param str notebook_id: the notebook id to be retrieved.
+        :return: notebook for the given info
+        :rtype: NoteBook
+        """
+
+        if not notebook_id:
+            raise RuntimeError('Provide notebook id option')
+
+        url = self.build_url(self._endpoints.get('get_notebook').format(id=notebook_id))
+
+        response = self.con.get(url)
+
+        data = response.json()
+
+        notebook = self.notebook_constructor(
+            parent=self,
+            **{self._cloud_data_key: data}
+        )
+
+        return notebook

--- a/O365/sharepoint.py
+++ b/O365/sharepoint.py
@@ -5,6 +5,7 @@ from dateutil.parser import parse
 from .utils import ApiComponent, TrackerSet, NEXT_LINK_KEYWORD, Pagination
 from .address_book import Contact
 from .drive import Storage
+from .notes import Notes
 
 log = logging.getLogger(__name__)
 
@@ -461,6 +462,10 @@ class Site(ApiComponent):
                                     main_resource='/sites/{id}'.format(
                                         id=self.object_id))
 
+        self.notes = Notes(parent=self,
+                           main_resource='/sites/{id}'.format(
+                            id=self.object_id))
+
     def __str__(self):
         return self.__repr__()
 
@@ -478,6 +483,9 @@ class Site(ApiComponent):
         :rtype: Drive
         """
         return self.site_storage.get_default_drive(request_drive=request_drive)
+
+    def get_notes(self):
+        return self.notes
 
     def get_document_library(self, drive_id):
         """ Returns a Document Library (a Drive instance)


### PR DESCRIPTION
This adds a base for OneNote support.
However, it needs a lot more work to be fully functional.
In its current state, it can get notebooks from a SharePoint site and list sections, pages, and content.
It's missing, pagination of sections and pages, create/edit notebooks, sections, pages, and more.

So, it's not ready for a merge, but I wanted to get it out there to get the discussion started and see if someone wants to help.

Example
```
sharepoint = account.sharepoint()

site = sharepoint.get_site('<site_id>')

notes = site.get_notes()

notebooks = notes.get_notebooks()

for notebook in notebooks:
    for section in notebook.get_sections():
        for page in section.get_pages():
            print(page.content)
```
            