### PR TITLE
Use upload session when attachment is larger then 3MB

### DIFF
--- a/O365/utils/attachment.py
+++ b/O365/utils/attachment.py
@@ -7,8 +7,8 @@ from .utils import ApiComponent
 
 log = logging.getLogger(__name__)
 
-UPLOAD_SIZE_LIMIT_SIMPLE = 1024 * 1024 * 4  # 4 MB
-DEFAULT_UPLOAD_CHUNK_SIZE = 1024 * 1024 * 4
+UPLOAD_SIZE_LIMIT_SIMPLE = 1024 * 1024 * 3  # 3 MB
+DEFAULT_UPLOAD_CHUNK_SIZE = 1024 * 1024 * 3
 
 class AttachableMixin:
     def __init__(self, attachment_name_property=None, attachment_type=None):


### PR DESCRIPTION
Just had a bug when attachment with size 3.8MB was throwing error


From official docs https://docs.microsoft.com/en-us/graph/outlook-large-attachments?tabs=http:
> - If the file size is under 3 MB, do a single POST on the attachments navigation property of the Outlook item; see how to do this for a message or for an event. The successful POST response includes the ID of the file attachment.
> - If the file size is between 3MB and 150MB, create an upload session, and iteratively use PUT to upload ranges of bytes of the file until you have uploaded the entire file. A header in the final successful PUT response includes a URL with the attachment ID.