### PR TITLE
calendar.py bugfix: AttributeError: 'Attendee' object has no attribute 'email'

### DIFF
--- a/O365/calendar.py
+++ b/O365/calendar.py
@@ -676,7 +676,7 @@ class Attendees(ApiComponent):
         return self.__attendees[key]
 
     def __contains__(self, item):
-        return item in {attendee.email for attendee in self.__attendees}
+        return item in {attendee.address for attendee in self.__attendees}
 
     def __len__(self):
         return len(self.__attendees)


### PR DESCRIPTION
I have come accross small issue when trying to check if email is in the list of current attendees of event:

```
return item in {attendee.email for attendee in self.__attendees}
AttributeError: 'Attendee' object has no attribute 'email'.
```

When I checked the code "Attendee" indeed does not have attribute "email". 
It has attribute address instead. This PR provides a quick & easy fix for that.