### PR TITLE
Support large mail attachments from memory

### DIFF
--- a/O365/utils/attachment.py
+++ b/O365/utils/attachment.py
@@ -74,7 +74,7 @@ class UploadSessionRequest(ApiComponent):
         attachment_item = {
             self._cc('attachmentType'): self._attachment.attachment_type,
             self._cc('name'): self._attachment.name,
-            self._cc('size'): self._attachment.attachment.stat().st_size
+            self._cc('size'): self._attachment.size
         }
         if self._attachment.is_inline:
             attachment_item[self._cc('isInline')] = self._attachment.is_inline
@@ -154,6 +154,7 @@ class BaseAttachment(ApiComponent):
                 file_obj, custom_name = attachment
                 if isinstance(file_obj, BytesIO):
                     # in memory objects
+                    self.size = file_obj.getbuffer().nbytes
                     self.content = base64.b64encode(file_obj.getvalue()).decode('utf-8')
                 else:
                     self.attachment = Path(file_obj)
@@ -475,7 +476,7 @@ class BaseAttachments(ApiComponent):
 
         for attachment in self.__attachments:
             if attachment.on_cloud is False:
-                file_size = attachment.attachment.stat().st_size
+                file_size = attachment.size
                 if file_size <= UPLOAD_SIZE_LIMIT_SIMPLE:
                     url = self.build_url(self._endpoints.get('attachments').format(
                         id=self._parent.object_id))


### PR DESCRIPTION
Current functionality for upload of attachments greater than 3MB in size is only supported for attachments written to disk (for in-memory attachments it throws an `AttributeError`). With this change, support is added for in-memory attachments, stored in the `content` attribute