### PR TITLE
Bugfix: Short-circuit attachment upload when 201 created received

### DIFF
--- a/O365/utils/attachment.py
+++ b/O365/utils/attachment.py
@@ -551,13 +551,16 @@ class BaseAttachments(ApiComponent):
                         return True
 
                     if attachment.attachment:
-                      with attachment.attachment.open(mode='rb') as file:
-                          read_from_file = lambda : file.read(chunk_size)
-                          return write_stream(read_byte_chunk=read_from_file)
+                        with attachment.attachment.open(mode='rb') as file:
+                            read_from_file = lambda : file.read(chunk_size)
+                            upload_completed = write_stream(read_byte_chunk=read_from_file)
                     else:
                         buffer = BytesIO(base64.b64decode(attachment.content))
-                        read_from_buffer = lambda : buffer.read(chunk_size)
-                        return write_stream(read_byte_chunk=read_from_buffer)
+                        read_byte_chunk = lambda : buffer.read(chunk_size)
+                        upload_completed = write_stream(read_byte_chunk=read_byte_chunk)
+
+                    if not upload_completed:
+                        return False
 
                 attachment.on_cloud = True
 


### PR DESCRIPTION
This fixes an introduced bug where `_update_attachments_to_cloud` only
PUT the first part of an attachment and never resulted in assignment
of "on_cloud"