### PR TITLE
Updated _get_child_folder() function in onedrive_example.py

### DIFF
--- a/examples/onedrive_example.py
+++ b/examples/onedrive_example.py
@@ -74,11 +74,8 @@ class O365Account():
 
     def _get_child_folder(self, folder, child_folder_name):
         items = folder.get_items()
-        child_folder_names = [item.name for item in items if item.is_folder]
-        if child_folder_name in child_folder_names:
-            return list(filter(lambda x: x.name == child_folder_name, items))[0]
-        else:
-            return folder.create_child_folder(child_folder_name)
+        match = list(filter(lambda x: x.name == child_folder_name and x.is_folder, items))
+        return match[0] if match else folder.create_child_folder(child_folder_name)
 
     ''' Get child folder, folder tree from root folder. If child folder not exist, make it. '''
 

--- a/examples/onedrive_example.py
+++ b/examples/onedrive_example.py
@@ -74,8 +74,8 @@ class O365Account():
 
     def _get_child_folder(self, folder, child_folder_name):
         items = folder.get_items()
-        match = list(filter(lambda x: x.name == child_folder_name and x.is_folder, items))
-        return match[0] if match else folder.create_child_folder(child_folder_name)
+        found_child = list(filter(lambda x: x.is_folder and x.name == child_folder_name, items))
+        return found_child[0] if found_child else folder.create_child_folder(child_folder_name)
 
     ''' Get child folder, folder tree from root folder. If child folder not exist, make it. '''
 


### PR DESCRIPTION
Hello,

While using the OneDrive functionality of this library, I came across and attempted to use the example function `upload_file()` in `onedrive_example.py`, but kept getting an `IndexError: list index out of range` exception when attempting to upload to a file path that already existed. After diving into the code, I found the bug inside of the _get_child_folder() function that is called within the `upload_file()` workflow.

Currently, the function gets a list of `DriveItem`'s by calling `get_items()`, then parses the list to create a new list of names of child folders. It then checks if the desired folder name is in that list, and either returns it if so or creates a new one if not. The problem is, after iterating over the `items` list to check the names, it seems the list is somehow 'consumed' and is an empty data structure (I am not sure if this is an intended feature of the `Pagination` class, but this is what the behavior reflected). It attempts to retrieve the file from a query over the now empty `items` list, which will result in the code attempting to return the first element in a list which will always be empty.

The new code reflects the intended functionality and is cleaner. It does both checks in one query over the `items` list and returns the appropriate item if found. A small change but this library has been helpful so I wished to contribute even if only minorly :)