### PR TITLE
bugfix for convert_to_pdf function

### DIFF
--- a/O365/drive.py
+++ b/O365/drive.py
@@ -63,7 +63,10 @@ class DownloadableMixin:
                 name = name + Path(self.name).suffix
 
             name = name or self.name
-            to_path = to_path / name
+            if convert_to_pdf:
+                to_path = to_path / Path(name).with_suffix(".pdf")
+            else:
+                to_path = to_path / name
 
         url = self.build_url(
             self._endpoints.get('download').format(id=self.object_id))


### PR DESCRIPTION
This is a fix for Issue #780
Without this fix when file is downloaded with convert_to_pdf == True - it downloaded with original extension (like .xlsx)
With this fix if convert_to_pdf == True extension of a file will be replaced with .pdf