### PR TITLE
Add support for "certificate" authentication

### DIFF
--- a/O365/account.py
+++ b/O365/account.py
@@ -34,12 +34,12 @@ class Account:
             # convert the provided scopes to protocol scopes:
             if scopes is not None:
                 kwargs['scopes'] = self.protocol.get_scopes_for(scopes)
-        elif auth_flow_type == 'credentials':
+        elif auth_flow_type in ('credentials', 'certificate'):
             # for client credential grant flow solely: add the default scope if it's not provided
             if not scopes:
                 kwargs['scopes'] = [self.protocol.prefix_scope('.default')]
             else:
-                raise ValueError('Auth flow type "credentials" does not require scopes')
+                raise ValueError(f'Auth flow type "{auth_flow_type}" does not require scopes')
         elif auth_flow_type == 'password':
             kwargs['scopes'] = self.protocol.get_scopes_for(scopes) if scopes else [self.protocol.prefix_scope('.default')]
 
@@ -49,7 +49,8 @@ class Account:
             if main_resource == ME_RESOURCE:
                 main_resource = ''
         else:
-            raise ValueError('"auth_flow_type" must be "authorization", "credentials", "password" or "public"')
+            raise ValueError('"auth_flow_type" must be "authorization", "credentials", "certificate", "password" or '
+                             '"public"')
 
         self.con = self.connection_constructor(credentials, **kwargs)
         self.main_resource = main_resource or self.protocol.default_resource
@@ -109,10 +110,11 @@ class Account:
                 print('Authentication Flow aborted.')
                 return False
 
-        elif self.con.auth_flow_type in ('credentials', 'password'):
+        elif self.con.auth_flow_type in ('credentials', 'certificate', 'password'):
             return self.con.request_token(None, requested_scopes=scopes)
         else:
-            raise ValueError('Connection "auth_flow_type" must be "authorization", "public", "password" or "credentials"')
+            raise ValueError('Connection "auth_flow_type" must be "authorization", "public", "password", "certificate"'
+                             ' or "credentials"')
 
     def get_current_user(self):
         """ Returns the current user """

--- a/examples/jwt_assertion.py
+++ b/examples/jwt_assertion.py
@@ -1,0 +1,65 @@
+import codecs
+import uuid
+from datetime import datetime, timezone, timedelta
+
+import jwt
+
+_ALGORITHM = "RS256"
+
+
+def _get_aud(tenant_id):
+    return f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+
+
+def create_jwt_assertion(private_key, tenant_id, thumbprint, client_id):
+    """
+    Create a JWT assertion, used to obtain an auth token.
+
+
+    @param private_key: Private key in PEM format from the certificate that was registered as credentials for the
+     application.
+    @param tenant_id: The directory tenant the application plans to operate against, in GUID or domain-name format.
+    @param thumbprint: The X.509 certificate thumbprint.
+    @param client_id: The application (client) ID that's assigned to the app.
+    @return: JWT assertion to be used to obtain an auth token.
+    """
+    x5t = codecs.encode(codecs.decode(thumbprint, "hex"), "base64").replace(b"\n", b"").decode()
+    aud = _get_aud(tenant_id)
+
+    now = datetime.now(tz=timezone.utc)
+    exp = now + timedelta(hours=1)
+    jti = str(uuid.uuid4())
+
+    payload = {
+        "aud": aud,
+        "exp": exp,
+        "iss": client_id,
+        "jti": jti,
+        "nbf": now,
+        "sub": client_id,
+        "iat": now
+    }
+    headers = {
+        "alg": _ALGORITHM,
+        "typ": "JWT",
+        "x5t": x5t,
+    }
+    encoded = jwt.encode(payload, private_key, algorithm=_ALGORITHM, headers=headers)
+
+    return encoded
+
+
+def decode_jwt_assertion(jwt_assertion, public_key, tenant_id):
+    """
+    Decode a JWT assertion, the opposite to 'create_jwt_assertion'.
+
+    @param jwt_assertion: The JWT assertion obtained to be decoded.
+    @param public_key: Public key in PEM format from the certificate that was registered as credentials for the
+     application.
+    @param tenant_id: The directory tenant the application plans to operate against, in GUID or domain-name format.
+    @return: The decoded assertion.
+    """
+    aud = _get_aud(tenant_id)
+    decoded = jwt.decode(jwt_assertion, public_key, audience=aud, algorithms=[_ALGORITHM])
+
+    return decoded


### PR DESCRIPTION
This method utilizes a JWT assertion to obtain the access token, as described in:
https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#second-case-access-token-request-with-a-certificate.

An example is also included with a helper to create the JWT assertion using the Private Key (PEM format), as described in: https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-certificate-credentials

This helper uses pyjwt. Since we need to encode the assertion with RS256, the 'cryptography' module is also required, as described in: https://pyjwt.readthedocs.io/en/stable/usage.html#encoding-decoding-tokens-with-rs256-rsa