### PR TITLE
fixed the all-day events time representation

### DIFF
--- a/O365/calendar.py
+++ b/O365/calendar.py
@@ -861,11 +861,13 @@ class Event(ApiComponent, AttachableMixin, HandleRecipientsMixin):
         self.__modified = parse(self.__modified).astimezone(
             local_tz) if self.__modified else None
 
+        self.__is_all_day = cloud_data.get(cc('isAllDay'), False)
+
         start_obj = cloud_data.get(cc('start'), {})
-        self.__start = self._parse_date_time_time_zone(start_obj)
+        self.__start = self._parse_date_time_time_zone(start_obj, self.__is_all_day)
 
         end_obj = cloud_data.get(cc('end'), {})
-        self.__end = self._parse_date_time_time_zone(end_obj)
+        self.__end = self._parse_date_time_time_zone(end_obj, self.__is_all_day)
 
         self.has_attachments = cloud_data.get(cc('hasAttachments'), False)
         self.__attachments = EventAttachments(parent=self, attachments=[])
@@ -875,7 +877,6 @@ class Event(ApiComponent, AttachableMixin, HandleRecipientsMixin):
         self.ical_uid = cloud_data.get(cc('iCalUId'), None)
         self.__importance = ImportanceLevel.from_value(
             cloud_data.get(cc('importance'), 'normal') or 'normal')
-        self.__is_all_day = cloud_data.get(cc('isAllDay'), False)
         self.is_cancelled = cloud_data.get(cc('isCancelled'), False)
         self.is_organizer = cloud_data.get(cc('isOrganizer'), True)
         self.__location = cloud_data.get(cc('location'), {})

--- a/O365/utils/utils.py
+++ b/O365/utils/utils.py
@@ -411,7 +411,7 @@ class ApiComponent:
         """ Alias for protocol.convert_case """
         return self.protocol.convert_case(dict_key)
 
-    def _parse_date_time_time_zone(self, date_time_time_zone):
+    def _parse_date_time_time_zone(self, date_time_time_zone, is_all_day=False):
         """ Parses and convert to protocol timezone a dateTimeTimeZone resource
         This resource is a dict with a date time and a windows timezone
         This is a common structure on Microsoft apis so it's included here.
@@ -434,7 +434,10 @@ class ApiComponent:
                 date_time = None
 
             if date_time and timezone != local_tz:
-                date_time = date_time.astimezone(local_tz)
+                if not is_all_day:
+                    date_time = date_time.astimezone(local_tz)
+                else:
+                    date_time = date_time.replace(tzinfo=local_tz)
         else:
             # Outlook v1.0 api compatibility (fallback to datetime string)
             try:


### PR DESCRIPTION
According to this [issue](https://github.com/O365/python-o365/issues/838) (#838 ), the representation datetime of an all-day event was not correct as +3 house was added to an aware-datetime with the turkey timezone. This PR will resolve this issue. 