### PR TITLE
Extend mailbox settings

### DIFF
--- a/O365/connection.py
+++ b/O365/connection.py
@@ -35,6 +35,7 @@ DEFAULT_SCOPES = {
     'basic': [('offline_access',), 'User.Read'],
     'mailbox': ['Mail.Read'],
     'mailbox_shared': ['Mail.Read.Shared'],
+    "mailbox_settings": ["MailboxSettings.ReadWrite"],
     'message_send': ['Mail.Send'],
     'message_send_shared': ['Mail.Send.Shared'],
     'message_all': ['Mail.ReadWrite', 'Mail.Send'],

--- a/O365/mailbox.py
+++ b/O365/mailbox.py
@@ -161,6 +161,8 @@ class AutomaticRepliesSettings(ApiComponent):
 
     @external_audience.setter
     def external_audience(self, value: ExternalAudience = ExternalAudience.ALL):
+        if not value:
+            value = ExternalAudience.ALL
         self.__external_audience = ExternalAudience(value)
 
 

--- a/O365/mailbox.py
+++ b/O365/mailbox.py
@@ -3,10 +3,15 @@ import logging
 from enum import Enum
 
 from .message import Message
-from .utils import Pagination, NEXT_LINK_KEYWORD, \
-    OutlookWellKnowFolderNames, ApiComponent
+from .utils import (
+    NEXT_LINK_KEYWORD,
+    ApiComponent,
+    OutlookWellKnowFolderNames,
+    Pagination,
+)
 
 log = logging.getLogger(__name__)
+
 
 class ExternalAudience(Enum):
     """Valid values for externalAudience."""
@@ -23,23 +28,24 @@ class AutoReplyStatus(Enum):
     ALWAYSENABLED = "alwaysEnabled"
     SCHEDULED = "scheduled"
 
+
 class Folder(ApiComponent):
-    """ A Mail Folder representation """
+    """A Mail Folder representation."""
 
     _endpoints = {
-        'root_folders': '/mailFolders',
-        'child_folders': '/mailFolders/{id}/childFolders',
-        'get_folder': '/mailFolders/{id}',
-        'root_messages': '/messages',
-        'folder_messages': '/mailFolders/{id}/messages',
-        'copy_folder': '/mailFolders/{id}/copy',
-        'move_folder': '/mailFolders/{id}/move',
-        'message': '/messages/{id}',
+        "root_folders": "/mailFolders",
+        "child_folders": "/mailFolders/{id}/childFolders",
+        "get_folder": "/mailFolders/{id}",
+        "root_messages": "/messages",
+        "folder_messages": "/mailFolders/{id}/messages",
+        "copy_folder": "/mailFolders/{id}/copy",
+        "move_folder": "/mailFolders/{id}/move",
+        "message": "/messages/{id}",
     }
     message_constructor = Message
 
     def __init__(self, *, parent=None, con=None, **kwargs):
-        """ Create an instance to represent the specified folder un given
+        """Create an instance to represent the specified folder in given
         parent folder
 
         :param parent: parent folder/account for this folder
@@ -53,54 +59,51 @@ class Folder(ApiComponent):
         :param str folder_id: id of the folder to get under the parent (kwargs)
         """
         if parent and con:
-            raise ValueError('Need a parent or a connection but not both')
+            raise ValueError("Need a parent or a connection but not both")
         self.con = parent.con if parent else con
         self.parent = parent if isinstance(parent, Folder) else None
 
         # This folder has no parents if root = True.
-        self.root = kwargs.pop('root', False)
+        self.root = kwargs.pop("root", False)
 
         # Choose the main_resource passed in kwargs over parent main_resource
-        main_resource = kwargs.pop('main_resource', None) or (
-            getattr(parent, 'main_resource', None) if parent else None)
+        main_resource = kwargs.pop("main_resource", None) or (
+            getattr(parent, "main_resource", None) if parent else None
+        )
 
         super().__init__(
-            protocol=parent.protocol if parent else kwargs.get('protocol'),
-            main_resource=main_resource)
+            protocol=parent.protocol if parent else kwargs.get("protocol"),
+            main_resource=main_resource,
+        )
 
         cloud_data = kwargs.get(self._cloud_data_key, {})
 
         # Fallback to manual folder if nothing available on cloud data
-        self.name = cloud_data.get(self._cc('displayName'),
-                                   kwargs.get('name',
-                                              ''))
+        self.name = cloud_data.get(self._cc("displayName"), kwargs.get("name", ""))
         if self.root is False:
             # Fallback to manual folder if nothing available on cloud data
-            self.folder_id = cloud_data.get(self._cc('id'),
-                                            kwargs.get('folder_id',
-                                                       None))
-            self.parent_id = cloud_data.get(self._cc('parentFolderId'), None)
-            self.child_folders_count = cloud_data.get(
-                self._cc('childFolderCount'), 0)
-            self.unread_items_count = cloud_data.get(
-                self._cc('unreadItemCount'), 0)
-            self.total_items_count = cloud_data.get(self._cc('totalItemCount'),
-                                                    0)
+            self.folder_id = cloud_data.get(
+                self._cc("id"), kwargs.get("folder_id", None)
+            )
+            self.parent_id = cloud_data.get(self._cc("parentFolderId"), None)
+            self.child_folders_count = cloud_data.get(self._cc("childFolderCount"), 0)
+            self.unread_items_count = cloud_data.get(self._cc("unreadItemCount"), 0)
+            self.total_items_count = cloud_data.get(self._cc("totalItemCount"), 0)
             self.updated_at = dt.datetime.now()
         else:
-            self.folder_id = 'root'
+            self.folder_id = "root"
 
     def __str__(self):
         return self.__repr__()
 
     def __repr__(self):
-        return '{} from resource: {}'.format(self.name, self.main_resource)
+        return "{} from resource: {}".format(self.name, self.main_resource)
 
     def __eq__(self, other):
         return self.folder_id == other.folder_id
 
     def get_folders(self, limit=None, *, query=None, order_by=None, batch=None):
-        """ Returns a list of child folders matching the query
+        """Return a list of child folders matching the query.
 
         :param int limit: max no. of folders to get. Over 999 uses batch.
         :param query: applies a filter to the request such as
@@ -113,24 +116,24 @@ class Folder(ApiComponent):
         :return: list of folders
         :rtype: list[mailbox.Folder] or Pagination
         """
-
         if self.root:
-            url = self.build_url(self._endpoints.get('root_folders'))
+            url = self.build_url(self._endpoints.get("root_folders"))
         else:
             url = self.build_url(
-                self._endpoints.get('child_folders').format(id=self.folder_id))
+                self._endpoints.get("child_folders").format(id=self.folder_id)
+            )
 
         if limit is None or limit > self.protocol.max_top_value:
             batch = self.protocol.max_top_value
 
-        params = {'$top': batch if batch else limit}
+        params = {"$top": batch if batch else limit}
 
         if order_by:
-            params['$orderby'] = order_by
+            params["$orderby"] = order_by
 
         if query:
             if isinstance(query, str):
-                params['$filter'] = query
+                params["$filter"] = query
             else:
                 params.update(query.as_params())
 
@@ -141,18 +144,25 @@ class Folder(ApiComponent):
         data = response.json()
 
         # Everything received from cloud must be passed as self._cloud_data_key
-        self_class = getattr(self, 'folder_constructor', type(self))
-        folders = [self_class(parent=self, **{self._cloud_data_key: folder}) for
-                   folder in data.get('value', [])]
+        self_class = getattr(self, "folder_constructor", type(self))
+        folders = [
+            self_class(parent=self, **{self._cloud_data_key: folder})
+            for folder in data.get("value", [])
+        ]
         next_link = data.get(NEXT_LINK_KEYWORD, None)
         if batch and next_link:
-            return Pagination(parent=self, data=folders, constructor=self_class,
-                              next_link=next_link, limit=limit)
+            return Pagination(
+                parent=self,
+                data=folders,
+                constructor=self_class,
+                next_link=next_link,
+                limit=limit,
+            )
         else:
             return folders
 
     def get_message(self, object_id=None, query=None, *, download_attachments=False):
-        """ Get one message from the query result.
+        """Get one message from the query result.
          A shortcut to get_messages with limit=1
         :param object_id: the message id to be retrieved.
         :param query: applies a filter to the request such as
@@ -163,10 +173,10 @@ class Folder(ApiComponent):
         :rtype: Message or None
         """
         if object_id is None and query is None:
-            raise ValueError('Must provide object id or query.')
+            raise ValueError("Must provide object id or query.")
 
         if object_id is not None:
-            url = self.build_url(self._endpoints.get('message').format(id=object_id))
+            url = self.build_url(self._endpoints.get("message").format(id=object_id))
             params = None
             if query and (query.has_selects or query.has_expands):
                 params = query.as_params()
@@ -176,18 +186,30 @@ class Folder(ApiComponent):
 
             message = response.json()
 
-            return self.message_constructor(parent=self,
-                                            download_attachments=download_attachments,
-                                            **{self._cloud_data_key: message})
+            return self.message_constructor(
+                parent=self,
+                download_attachments=download_attachments,
+                **{self._cloud_data_key: message},
+            )
 
         else:
-            messages = list(self.get_messages(limit=1, query=query,
-                                              download_attachments=download_attachments))
+            messages = list(
+                self.get_messages(
+                    limit=1, query=query, download_attachments=download_attachments
+                )
+            )
 
             return messages[0] if messages else None
 
-    def get_messages(self, limit=25, *, query=None, order_by=None, batch=None,
-                     download_attachments=False):
+    def get_messages(
+        self,
+        limit=25,
+        *,
+        query=None,
+        order_by=None,
+        batch=None,
+        download_attachments=False,
+    ):
         """
         Downloads messages from this folder
 
@@ -205,22 +227,23 @@ class Folder(ApiComponent):
         """
 
         if self.root:
-            url = self.build_url(self._endpoints.get('root_messages'))
+            url = self.build_url(self._endpoints.get("root_messages"))
         else:
-            url = self.build_url(self._endpoints.get('folder_messages').format(
-                id=self.folder_id))
+            url = self.build_url(
+                self._endpoints.get("folder_messages").format(id=self.folder_id)
+            )
 
         if not batch and (limit is None or limit > self.protocol.max_top_value):
             batch = self.protocol.max_top_value
 
-        params = {'$top': batch if batch else limit}
+        params = {"$top": batch if batch else limit}
 
         if order_by:
-            params['$orderby'] = order_by
+            params["$orderby"] = order_by
 
         if query:
             if isinstance(query, str):
-                params['$filter'] = query
+                params["$filter"] = query
             else:
                 params.update(query.as_params())
 
@@ -231,23 +254,30 @@ class Folder(ApiComponent):
         data = response.json()
 
         # Everything received from cloud must be passed as self._cloud_data_key
-        messages = (self.message_constructor(
-            parent=self,
-            download_attachments=download_attachments,
-            **{self._cloud_data_key: message})
-            for message in data.get('value', []))
+        messages = (
+            self.message_constructor(
+                parent=self,
+                download_attachments=download_attachments,
+                **{self._cloud_data_key: message},
+            )
+            for message in data.get("value", [])
+        )
 
         next_link = data.get(NEXT_LINK_KEYWORD, None)
         if batch and next_link:
-            return Pagination(parent=self, data=messages,
-                              constructor=self.message_constructor,
-                              next_link=next_link, limit=limit,
-                              download_attachments=download_attachments)
+            return Pagination(
+                parent=self,
+                data=messages,
+                constructor=self.message_constructor,
+                next_link=next_link,
+                limit=limit,
+                download_attachments=download_attachments,
+            )
         else:
             return messages
 
     def create_child_folder(self, folder_name):
-        """ Creates a new child folder under this folder
+        """Creates a new child folder under this folder
 
         :param str folder_name: name of the folder to add
         :return: newly created folder
@@ -257,24 +287,24 @@ class Folder(ApiComponent):
             return None
 
         if self.root:
-            url = self.build_url(self._endpoints.get('root_folders'))
+            url = self.build_url(self._endpoints.get("root_folders"))
         else:
             url = self.build_url(
-                self._endpoints.get('child_folders').format(id=self.folder_id))
+                self._endpoints.get("child_folders").format(id=self.folder_id)
+            )
 
-        response = self.con.post(url,
-                                 data={self._cc('displayName'): folder_name})
+        response = self.con.post(url, data={self._cc("displayName"): folder_name})
         if not response:
             return None
 
         folder = response.json()
 
-        self_class = getattr(self, 'folder_constructor', type(self))
+        self_class = getattr(self, "folder_constructor", type(self))
         # Everything received from cloud must be passed as self._cloud_data_key
         return self_class(parent=self, **{self._cloud_data_key: folder})
 
     def get_folder(self, *, folder_id=None, folder_name=None):
-        """ Get a folder by it's id or name
+        """Get a folder by it's id or name
 
         :param str folder_id: the folder_id to be retrieved.
          Can be any folder Id (child or not)
@@ -284,26 +314,27 @@ class Folder(ApiComponent):
         :rtype: mailbox.Folder or None
         """
         if folder_id and folder_name:
-            raise RuntimeError('Provide only one of the options')
+            raise RuntimeError("Provide only one of the options")
 
         if not folder_id and not folder_name:
-            raise RuntimeError('Provide one of the options')
+            raise RuntimeError("Provide one of the options")
 
         if folder_id:
             # get folder by it's id, independent of the parent of this folder_id
-            url = self.build_url(
-                self._endpoints.get('get_folder').format(id=folder_id))
+            url = self.build_url(self._endpoints.get("get_folder").format(id=folder_id))
             params = None
         else:
             # get folder by name. Only looks up in child folders.
             if self.root:
-                url = self.build_url(self._endpoints.get('root_folders'))
+                url = self.build_url(self._endpoints.get("root_folders"))
             else:
                 url = self.build_url(
-                    self._endpoints.get('child_folders').format(
-                        id=self.folder_id))
-            params = {'$filter': "{} eq '{}'".format(self._cc('displayName'),
-                                                     folder_name), '$top': 1}
+                    self._endpoints.get("child_folders").format(id=self.folder_id)
+                )
+            params = {
+                "$filter": "{} eq '{}'".format(self._cc("displayName"), folder_name),
+                "$top": 1,
+            }
 
         response = self.con.get(url, params=params)
         if not response:
@@ -312,20 +343,23 @@ class Folder(ApiComponent):
         if folder_id:
             folder = response.json()
         else:
-            folder = response.json().get('value')
+            folder = response.json().get("value")
             folder = folder[0] if folder else None
             if folder is None:
                 return None
 
-        self_class = getattr(self, 'folder_constructor', type(self))
+        self_class = getattr(self, "folder_constructor", type(self))
         # Everything received from cloud must be passed as self._cloud_data_key
         # We don't pass parent, as this folder may not be a child of self.
-        return self_class(con=self.con, protocol=self.protocol,
-                          main_resource=self.main_resource,
-                          **{self._cloud_data_key: folder})
+        return self_class(
+            con=self.con,
+            protocol=self.protocol,
+            main_resource=self.main_resource,
+            **{self._cloud_data_key: folder},
+        )
 
     def refresh_folder(self, update_parent_if_changed=False):
-        """ Re-download folder data
+        """Re-download folder data
         Inbox Folder will be unable to download its own data (no folder_id)
 
         :param bool update_parent_if_changed: updates self.parent with new
@@ -333,7 +367,7 @@ class Folder(ApiComponent):
         :return: Refreshed or Not
         :rtype: bool
         """
-        folder_id = getattr(self, 'folder_id', None)
+        folder_id = getattr(self, "folder_id", None)
         if self.root or folder_id is None:
             return False
 
@@ -345,8 +379,9 @@ class Folder(ApiComponent):
         if folder.parent_id and self.parent_id:
             if folder.parent_id != self.parent_id:
                 self.parent_id = folder.parent_id
-                self.parent = (self.get_parent_folder()
-                               if update_parent_if_changed else None)
+                self.parent = (
+                    self.get_parent_folder() if update_parent_if_changed else None
+                )
         self.child_folders_count = folder.child_folders_count
         self.unread_items_count = folder.unread_items_count
         self.total_items_count = folder.total_items_count
@@ -355,7 +390,7 @@ class Folder(ApiComponent):
         return True
 
     def get_parent_folder(self):
-        """ Get the parent folder from attribute self.parent or
+        """Get the parent folder from attribute self.parent or
         getting it from the cloud
 
         :return: Parent Folder
@@ -371,7 +406,7 @@ class Folder(ApiComponent):
         return self.parent
 
     def update_folder_name(self, name, update_folder_data=True):
-        """ Change this folder name
+        """Change this folder name
 
         :param str name: new name to change to
         :param bool update_folder_data: whether or not to re-fetch the data
@@ -384,9 +419,10 @@ class Folder(ApiComponent):
             return False
 
         url = self.build_url(
-            self._endpoints.get('get_folder').format(id=self.folder_id))
+            self._endpoints.get("get_folder").format(id=self.folder_id)
+        )
 
-        response = self.con.patch(url, data={self._cc('displayName'): name})
+        response = self.con.patch(url, data={self._cc("displayName"): name})
         if not response:
             return False
 
@@ -396,17 +432,17 @@ class Folder(ApiComponent):
 
         folder = response.json()
 
-        self.name = folder.get(self._cc('displayName'), '')
-        self.parent_id = folder.get(self._cc('parentFolderId'), None)
-        self.child_folders_count = folder.get(self._cc('childFolderCount'), 0)
-        self.unread_items_count = folder.get(self._cc('unreadItemCount'), 0)
-        self.total_items_count = folder.get(self._cc('totalItemCount'), 0)
+        self.name = folder.get(self._cc("displayName"), "")
+        self.parent_id = folder.get(self._cc("parentFolderId"), None)
+        self.child_folders_count = folder.get(self._cc("childFolderCount"), 0)
+        self.unread_items_count = folder.get(self._cc("unreadItemCount"), 0)
+        self.total_items_count = folder.get(self._cc("totalItemCount"), 0)
         self.updated_at = dt.datetime.now()
 
         return True
 
     def delete(self):
-        """ Deletes this folder
+        """Deletes this folder
 
         :return: Deleted or Not
         :rtype: bool
@@ -416,7 +452,8 @@ class Folder(ApiComponent):
             return False
 
         url = self.build_url(
-            self._endpoints.get('get_folder').format(id=self.folder_id))
+            self._endpoints.get("get_folder").format(id=self.folder_id)
+        )
 
         response = self.con.delete(url)
         if not response:
@@ -426,36 +463,40 @@ class Folder(ApiComponent):
         return True
 
     def copy_folder(self, to_folder):
-        """ Copy this folder and it's contents to into another folder
+        """Copy this folder and it's contents to into another folder
 
         :param to_folder: the destination Folder/folder_id to copy into
         :type to_folder: mailbox.Folder or str
         :return: The new folder after copying
         :rtype: mailbox.Folder or None
         """
-        to_folder_id = to_folder.folder_id if isinstance(to_folder,
-                                                         Folder) else to_folder
+        to_folder_id = (
+            to_folder.folder_id if isinstance(to_folder, Folder) else to_folder
+        )
 
         if self.root or not self.folder_id or not to_folder_id:
             return None
 
         url = self.build_url(
-            self._endpoints.get('copy_folder').format(id=self.folder_id))
+            self._endpoints.get("copy_folder").format(id=self.folder_id)
+        )
 
-        response = self.con.post(url,
-                                 data={self._cc('destinationId'): to_folder_id})
+        response = self.con.post(url, data={self._cc("destinationId"): to_folder_id})
         if not response:
             return None
 
         folder = response.json()
 
-        self_class = getattr(self, 'folder_constructor', type(self))
+        self_class = getattr(self, "folder_constructor", type(self))
         # Everything received from cloud must be passed as self._cloud_data_key
-        return self_class(con=self.con, main_resource=self.main_resource,
-                          **{self._cloud_data_key: folder})
+        return self_class(
+            con=self.con,
+            main_resource=self.main_resource,
+            **{self._cloud_data_key: folder},
+        )
 
     def move_folder(self, to_folder, *, update_parent_if_changed=True):
-        """ Move this folder to another folder
+        """Move this folder to another folder
 
         :param to_folder: the destination Folder/folder_id to move into
         :type to_folder: mailbox.Folder or str
@@ -464,34 +505,36 @@ class Folder(ApiComponent):
         :return: The new folder after copying
         :rtype: mailbox.Folder or None
         """
-        to_folder_id = to_folder.folder_id if isinstance(to_folder,
-                                                         Folder) else to_folder
+        to_folder_id = (
+            to_folder.folder_id if isinstance(to_folder, Folder) else to_folder
+        )
 
         if self.root or not self.folder_id or not to_folder_id:
             return False
 
         url = self.build_url(
-            self._endpoints.get('move_folder').format(id=self.folder_id))
+            self._endpoints.get("move_folder").format(id=self.folder_id)
+        )
 
-        response = self.con.post(url,
-                                 data={self._cc('destinationId'): to_folder_id})
+        response = self.con.post(url, data={self._cc("destinationId"): to_folder_id})
         if not response:
             return False
 
         folder = response.json()
 
-        parent_id = folder.get(self._cc('parentFolderId'), None)
+        parent_id = folder.get(self._cc("parentFolderId"), None)
 
         if parent_id and self.parent_id:
             if parent_id != self.parent_id:
                 self.parent_id = parent_id
-                self.parent = (self.get_parent_folder()
-                               if update_parent_if_changed else None)
+                self.parent = (
+                    self.get_parent_folder() if update_parent_if_changed else None
+                )
 
         return True
 
     def new_message(self):
-        """ Creates a new draft message under this folder
+        """Creates a new draft message under this folder
 
         :return: new Message
         :rtype: Message
@@ -507,7 +550,7 @@ class Folder(ApiComponent):
         return draft_message
 
     def delete_message(self, message):
-        """ Deletes a stored message
+        """Deletes a stored message
 
         :param message: message/message_id to delete
         :type message: Message or str
@@ -515,26 +558,17 @@ class Folder(ApiComponent):
         :rtype: bool
         """
 
-        message_id = message.object_id if isinstance(message,
-                                                     Message) else message
+        message_id = message.object_id if isinstance(message, Message) else message
 
         if message_id is None:
-            raise RuntimeError('Provide a valid Message or a message id')
+            raise RuntimeError("Provide a valid Message or a message id")
 
-        url = self.build_url(
-            self._endpoints.get('message').format(id=message_id))
+        url = self.build_url(self._endpoints.get("message").format(id=message_id))
 
         response = self.con.delete(url)
 
         return bool(response)
 
-
-class MailBox(Folder):
-    folder_constructor = Folder
-
-    def __init__(self, *, parent=None, con=None, **kwargs):
-        super().__init__(parent=parent, con=con, root=True, **kwargs)
-        self._endpoints["settings"] = "/mailboxSettings"
 
 class MailBox(Folder):
     folder_constructor = Folder
@@ -556,10 +590,7 @@ class MailBox(Folder):
         :return: Success / Failure
         :rtype: bool
         """
-        if externalAudience:
-            externalAudience = ExternalAudience(externalAudience)
-        else:
-            externalAudience = ExternalAudience.ALL
+        externalAudience = ExternalAudience(externalAudience)
         status = AutoReplyStatus.ALWAYSENABLED
         if scheduled_start_date_time or scheduled_end_date_time:
             status = AutoReplyStatus.SCHEDULED
@@ -604,19 +635,19 @@ class MailBox(Folder):
             value = self.protocol.timezone.localize(value)
         elif value.tzinfo != self.protocol.timezone:
             value = value.astimezone(self.protocol.timezone)
-        return value    
+        return value
 
     def set_disable_reply(self):
-        """ Disable the automatic reply for the mailbox.
+        """Disable the automatic reply for the mailbox.
 
         :return: Success / Failure
         :rtype: bool
         """
-        url = self.build_url(self._endpoints.get('settings'))
+        url = self.build_url(self._endpoints.get("settings"))
 
         data = {
-            self._cc('automaticRepliesSetting'): {
-                self._cc('status'): 'disabled',
+            self._cc("automaticRepliesSetting"): {
+                self._cc("status"): "disabled",
             }
         }
 
@@ -625,64 +656,74 @@ class MailBox(Folder):
         return bool(response)
 
     def inbox_folder(self):
-        """ Shortcut to get Inbox Folder instance
+        """Shortcut to get Inbox Folder instance
 
         :rtype: mailbox.Folder
         """
-        return self.folder_constructor(parent=self, name='Inbox',
-                                       folder_id=OutlookWellKnowFolderNames
-                                       .INBOX.value)
+        return self.folder_constructor(
+            parent=self, name="Inbox", folder_id=OutlookWellKnowFolderNames.INBOX.value
+        )
 
     def junk_folder(self):
-        """ Shortcut to get Junk Folder instance
+        """Shortcut to get Junk Folder instance
 
         :rtype: mailbox.Folder
         """
-        return self.folder_constructor(parent=self, name='Junk',
-                                       folder_id=OutlookWellKnowFolderNames
-                                       .JUNK.value)
+        return self.folder_constructor(
+            parent=self, name="Junk", folder_id=OutlookWellKnowFolderNames.JUNK.value
+        )
 
     def deleted_folder(self):
-        """ Shortcut to get DeletedItems Folder instance
+        """Shortcut to get DeletedItems Folder instance
 
         :rtype: mailbox.Folder
         """
-        return self.folder_constructor(parent=self, name='DeletedItems',
-                                       folder_id=OutlookWellKnowFolderNames
-                                       .DELETED.value)
+        return self.folder_constructor(
+            parent=self,
+            name="DeletedItems",
+            folder_id=OutlookWellKnowFolderNames.DELETED.value,
+        )
 
     def drafts_folder(self):
-        """ Shortcut to get Drafts Folder instance
+        """Shortcut to get Drafts Folder instance
 
         :rtype: mailbox.Folder
         """
-        return self.folder_constructor(parent=self, name='Drafts',
-                                       folder_id=OutlookWellKnowFolderNames
-                                       .DRAFTS.value)
+        return self.folder_constructor(
+            parent=self,
+            name="Drafts",
+            folder_id=OutlookWellKnowFolderNames.DRAFTS.value,
+        )
 
     def sent_folder(self):
-        """ Shortcut to get SentItems Folder instance
+        """Shortcut to get SentItems Folder instance
 
         :rtype: mailbox.Folder
         """
-        return self.folder_constructor(parent=self, name='SentItems',
-                                       folder_id=OutlookWellKnowFolderNames
-                                       .SENT.value)
+        return self.folder_constructor(
+            parent=self,
+            name="SentItems",
+            folder_id=OutlookWellKnowFolderNames.SENT.value,
+        )
 
     def outbox_folder(self):
-        """ Shortcut to get Outbox Folder instance
+        """Shortcut to get Outbox Folder instance
 
         :rtype: mailbox.Folder
         """
-        return self.folder_constructor(parent=self, name='Outbox',
-                                       folder_id=OutlookWellKnowFolderNames
-                                       .OUTBOX.value)
+        return self.folder_constructor(
+            parent=self,
+            name="Outbox",
+            folder_id=OutlookWellKnowFolderNames.OUTBOX.value,
+        )
 
     def archive_folder(self):
-        """ Shortcut to get Archive Folder instance
+        """Shortcut to get Archive Folder instance
 
         :rtype: mailbox.Folder
         """
-        return self.folder_constructor(parent=self, name='Archive',
-                                       folder_id=OutlookWellKnowFolderNames
-                                       .ARCHIVE.value)
+        return self.folder_constructor(
+            parent=self,
+            name="Archive",
+            folder_id=OutlookWellKnowFolderNames.ARCHIVE.value,
+        )

--- a/README.md
+++ b/README.md
@@ -366,13 +366,14 @@ account.authenticate()
 ```
 
 Scope implementation depends on the protocol used. So by using protocol data you can automatically set the scopes needed.
-This is implemented by using 'scope helpers'. Those are little helpers that group scope functionallity and abstract the procotol used.
+This is implemented by using 'scope helpers'. Those are little helpers that group scope functionality and abstract the protocol used.
 
 Scope Helper                       | Scopes included
 :---                               | :---
 basic                              | 'offline_access' and 'User.Read'
 mailbox                            | 'Mail.Read'
 mailbox_shared                     | 'Mail.Read.Shared'
+mailbox_settings                   | 'MailboxSettings.ReadWrite'
 message_send                       | 'Mail.Send'
 message_send_shared                | 'Mail.Send.Shared'
 message_all                        | 'Mail.ReadWrite' and 'Mail.Send'
@@ -667,14 +668,14 @@ Mailbox groups the funcionality of both the messages and the email folders.
 
 These are the scopes needed to work with the `MailBox` and `Message` classes.
 
- Raw Scope                |  Included in Scope Helper                   | Description
- :---:                    |  :---:                                     | ---
- *Mail.Read*              |  *mailbox*                                 | To only read my mailbox
- *Mail.Read.Shared*       |  *mailbox_shared*                          | To only read another user / shared mailboxes
- *Mail.Send*              |  *message_send, message_all*               | To only send message
- *Mail.Send.Shared*       |  *message_send_shared, message_all_shared* | To only send message as another user / shared mailbox
- *Mail.ReadWrite*         |  *message_all*                             | To read and save messages in my mailbox
- *Mail.ReadWrite.Shared*  |  *message_all_shared*                      | To read and save messages in another user / shared mailbox
+ Raw Scope                   |  Included in Scope Helper                  | Description
+ :---:                       |  :---:                                     | ---
+ *Mail.Read*                 |  *mailbox*                                 | To only read my mailbox
+ *Mail.Read.Shared*          |  *mailbox_shared*                          | To only read another user / shared mailboxes
+ *Mail.Send*                 |  *message_send, message_all*               | To only send message
+ *Mail.Send.Shared*          |  *message_send_shared, message_all_shared* | To only send message as another user / shared mailbox
+ *Mail.ReadWrite*            |  *message_all*                             | To read and save messages in my mailbox
+ *MailboxSettings.ReadWrite* |  *mailbox_settings*                        | To read and write suer mailbox settings
 
 ```python
 mailbox = account.mailbox()
@@ -715,7 +716,7 @@ new_folder = archive.create_child_folder('George Best Quotes')
 ```
 
 #### Message
-An email object with all it's data and methods.
+An email object with all its data and methods.
 
 Creating a draft message is as easy as this:
 ```python
@@ -803,8 +804,41 @@ Messages and attached messages can be saved as *.eml.
         msg.attachments.save_as_eml(msg_attachment, to_path=Path('my_saved_email.eml'))
     ```
 
+#### Mailbox Settings
+The mailbox settings and associated methods.
+
+Retrieve and update mailbox auto reply settings:
+```python
+from O365.mailbox import AutoReplyStatus, ExternalAudience
+
+mailboxsettings = mailbox.get_settings()
+ars = mailboxsettings.automaticrepliessettings
+
+ars.scheduled_startdatetime = start # Sets the start date/time
+ars.scheduled_enddatetime = end # Sets the end date/time
+ars.status = AutoReplyStatus.SCHEDULED # DISABLED/SCHEDULED/ALWAYSENABLED - Uses start/end date/time if scheduled.
+ars.external_audience = ExternalAudience.NONE # NONE/CONTACTSONLY/ALL
+ars.internal_reply_message = "ARS Internal" # Internal message
+ars.external_reply_message = "ARS External" # External message
+mailboxsettings.save()
+```
+
+Alternatively to enable and disable
+```python
+mailboxsettings.save()
+
+mailbox.set_automatic_reply(
+    "Internal",
+    "External",
+    scheduled_start_date_time=start, # Status will be 'scheduled' if start/end supplied, otherwise 'alwaysEnabled'
+    scheduled_end_date_time=end,
+    externalAudience=ExternalAudience.NONE, # Defaults to ALL
+)
+mailbox.set_disable_reply()
+```
+
 ## AddressBook
-AddressBook groups the funcionality of both the Contact Folders and Contacts. Outlook Distribution Groups are not supported (By the Microsoft API's).
+AddressBook groups the functionality of both the Contact Folders and Contacts. Outlook Distribution Groups are not supported (By the Microsoft API's).
 
 These are the scopes needed to work with the `AddressBook` and `Contact` classes.
 


### PR DESCRIPTION
This PR extends the setting of auto_reply status, to setup for for full mailbox settings retrieval.

- Enables getting of autoreply settings as a subclass to mailbox settings (as it is in the MS Graph API - https://learn.microsoft.com/en-us/graph/api/user-get-mailboxsettings?view=graph-rest-1.0&tabs=http)
- Once retrieved, the settings can then be altered individually.
- Alters mailbox.set_automatic_reply/set_disable_reply to use the new classes, but does not alter the external calls to those methods

This should be easily extensible to retrieve all mailbox settings.

**Query** I've set the automaticrepliessettings class to be an ApiComponent. It has no direct api calls through it, they are all handled at MailboxSettings, so not sure if it needs to be an ApiComponent, but had to set it that way to enable cloud_data_key.

**Note** I submitted a baseline commit, because my setup, I think, formats with a slightly longer line length. So this will give you greater clarity on what I've actually changed if you look at the second commit.