### PR TITLE
fix the bug can not update Table show_headers and show_totals of Table

### DIFF
--- a/O365/excel.py
+++ b/O365/excel.py
@@ -1393,9 +1393,9 @@ class Table(ApiComponent):
         data = {}
         if name:
             data['name'] = name
-        if show_headers:
+        if show_headers is not None:
             data['showHeaders'] = show_headers
-        if show_totals:
+        if show_totals is not None:
             data['showTotals'] = show_totals
         if style:
             data['style'] = style


### PR DESCRIPTION
in excel.py -> Table -> update(), if show_headers or show_totals is False, then it won't be added into request, mentioned in [Issue 937](https://github.com/O365/python-o365/issues/937)