### PR TITLE
Rename UA Kyiv timezone

### DIFF
--- a/O365/utils/windows_tz.py
+++ b/O365/utils/windows_tz.py
@@ -453,7 +453,7 @@ IANA_TO_WIN = {
     "Europe/Istanbul": "Turkey Standard Time",
     "Europe/Jersey": "GMT Standard Time",
     "Europe/Kaliningrad": "Kaliningrad Standard Time",
-    "Europe/Kiev": "FLE Standard Time",
+    "Europe/Kyiv": "FLE Standard Time",
     "Europe/Kirov": "Russian Standard Time",
     "Europe/Lisbon": "GMT Standard Time",
     "Europe/Ljubljana": "Central European Standard Time",


### PR DESCRIPTION
Renamed "Europe/Kiev" to "Europe/Kyiv" as per ICANN's change: https://mm.icann.org/pipermail/tz-announce/2022-August/000071.html

Fixes error when using calendar with timezone "Europe/Kyiv":
`pytz.exceptions.UnknownTimeZoneError: "Can't find Iana TimeZone Europe/Kyiv"`