### PR TITLE
Add Calendar().hex_color property

### DIFF
--- a/O365/calendar.py
+++ b/O365/calendar.py
@@ -1613,6 +1613,10 @@ class Calendar(ApiComponent, HandleRecipientsMixin):
         self.can_share = cloud_data.get(self._cc('canShare'), False)
         self.can_view_private_items = cloud_data.get(
             self._cc('canViewPrivateItems'), False)
+        
+        # Hex color only returns a value when a custom calandar is set
+        # Hex color is read-only, cannot be used to set calendar's color
+        self.hex_color = cloud_data.get(self._cc('hexColor'), None)
 
     def __str__(self):
         return self.__repr__()


### PR DESCRIPTION
Adds `hex_color` property to `Calendar()`. If a user sets a custom calendar color on outlook.com, currently `Calendar()` will call `CalendarColor.from_value(color)` to convert it to a pre-defined color, but there are use cases where getting the actual color id is better suited. `hexColor` is a defined property according to https://learn.microsoft.com/en-us/graph/api/resources/calendar?view=graph-rest-1.0, and it is readily available for querying `cloud_data = ['id', 'name', 'color', 'hexColor', 'isDefaultCalendar', 'changeKey', 'canShare', 'canViewPrivateItems', 'canEdit', 'allowedOnlineMeetingProviders', 'defaultOnlineMeetingProvider', 'isTallyingResponses', 'isRemovable', 'owner']`