### PR TITLE
add missing format keyname for invoke_function endpoint

### DIFF
--- a/O365/excel.py
+++ b/O365/excel.py
@@ -1856,7 +1856,7 @@ class WorkBook(ApiComponent):
 
     def invoke_function(self, function_name, **function_params):
         """ Invokes an Excel Function """
-        url = self.build_url(self._endpoints.get('function').format(function_name))
+        url = self.build_url(self._endpoints.get('function').format(name=function_name))
         response = self.session.post(url, data=function_params)
         if not response:
             return None


### PR DESCRIPTION
Hi - it seems that the format key was missing for building the url for invoke_function.  This makes it work for me.