### PR TITLE
Add access to singleValueExtendedProperties in Message

### DIFF
--- a/O365/message.py
+++ b/O365/message.py
@@ -322,7 +322,7 @@ class Message(ApiComponent, AttachableMixin, HandleRecipientsMixin):
         meeting_mt = meeting_mt.replace('Tenatively', 'Tentatively')
 
         self.__meeting_message_type = MeetingMessageType.from_value(meeting_mt) if meeting_mt != 'none' else None
-        
+
         # a message is a draft by default
         self.__is_draft = cloud_data.get(cc('isDraft'), kwargs.get('is_draft',
                                                                    True))


### PR DESCRIPTION
Added single_value_extended_properties instance attribute and property so singleValueExtendedProperties can be accessed. This allows you to get information like the message size (singleValueExtendedProperty id LONG 0x0E08)