### PR TITLE
Pass keyword arguments to request_token also when auth_flow_type is credentials, certificate or password

### DIFF
--- a/O365/account.py
+++ b/O365/account.py
@@ -118,7 +118,7 @@ class Account:
                 return False
 
         elif self.con.auth_flow_type in ('credentials', 'certificate', 'password'):
-            return self.con.request_token(None, requested_scopes=scopes)
+            return self.con.request_token(None, requested_scopes=scopes, **kwargs)
         else:
             raise ValueError('Connection "auth_flow_type" must be "authorization", "public", "password", "certificate"'
                              ' or "credentials"')


### PR DESCRIPTION
When authenticating with "credentials", "certificate" or "password", there is no way to control the behaviour of `request_token` by passing extra keyword arguments. This is already possible for "authorization" and "public" authentication types.
This PR fixes that by passing the keyword arguments also when auth_flow_type in "credentials", "certificate" or "password".