### PR TITLE
Add Support for Disabling Forward Button in Calendar Invitations

### DIFF
--- a/O365/calendar.py
+++ b/O365/calendar.py
@@ -910,6 +910,7 @@ class Event(ApiComponent, AttachableMixin, HandleRecipientsMixin):
         self.series_master_id = cloud_data.get(cc('seriesMasterId'), None)
         self.__show_as = EventShowAs.from_value(cloud_data.get(cc('showAs'), 'busy'))
         self.__event_type = EventType.from_value(cloud_data.get(cc('type'), 'singleInstance'))
+        self.__no_forwarding = False
 
     def __str__(self):
         return self.__repr__()
@@ -958,6 +959,12 @@ class Event(ApiComponent, AttachableMixin, HandleRecipientsMixin):
             cc('showAs'): cc(self.__show_as.value),
             cc('isOnlineMeeting'): cc(self.__is_online_meeting),
             cc('onlineMeetingProvider'): cc(self.__online_meeting_provider.value),
+            cc("SingleValueExtendedProperties"): [
+                {
+                    "id": "Boolean {00020329-0000-0000-C000-000000000046} Name DoNotForward",
+                    "value": cc(self.__no_forwarding),
+                }
+            ],
         }
 
         if self.__recurrence:
@@ -1318,6 +1325,15 @@ class Event(ApiComponent, AttachableMixin, HandleRecipientsMixin):
         self.__online_meeting_provider = (value if isinstance(value, OnlineMeetingProviderType)
                              else OnlineMeetingProviderType.from_value(value))
         self._track_changes.add(self._cc('onlineMeetingProvider'))
+
+    @property
+    def no_forwarding(self):
+        return self.__no_forwarding
+
+    @no_forwarding.setter
+    def no_forwarding(self, value):
+        self.__no_forwarding = value
+        self._track_changes.add('SingleValueExtendedProperties')
 
     def get_occurrences(self, start, end, *, limit=None, query=None, order_by=None, batch=None):
         """


### PR DESCRIPTION
Hi,

I have prepared a small modification that allows users to disable the forward button in calendar invitations for a given event. This feature can be useful in scenarios where the event organizer wants to restrict the distribution of the event details.

Changes Made:
Added a new attribute __no_forwarding initialized to False.
Included SingleValueExtendedProperties in the to_api_data method to handle the "Do Not Forward" setting.
Added a property no_forwarding with its corresponding setter method to enable or disable this feature.
Usage:
To disable the forward button for an event, simply set the no_forwarding attribute to True:
```python
event.no_forwarding = True
```

I am attaching a screenshot to show how this looks in the event invitation:
![Screenshot](https://github.com/O365/python-o365/assets/56200795/e4060403-9b85-49e1-8198-5a65fcd41238)


