### PR TITLE
Update readme supported python version to match setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ What follows is kind of a wiki...
 ## Install
 O365 is available on pypi.org. Simply run `pip install O365` to install it.
 
-Requirements: >= Python 3.4
+Requirements: >= Python 3.9
 
 Project dependencies installed by pip:
  - requests


### PR DESCRIPTION
Readme listed python support >= 3.4, but setup.py states >=3.9. Updated readme to reflect setup.py.

Fixes (at least) #890 #880