### PR TITLE
Send naive request to monitor url

### DIFF
--- a/O365/drive.py
+++ b/O365/drive.py
@@ -174,7 +174,7 @@ class CopyOperation(ApiComponent):
         if self.item_id:
             return True
 
-        response = self.con.get(self.monitor_url)
+        response = self.con.naive_request(self.monitor_url, method="get")
         if not response:
             return False
 


### PR DESCRIPTION
to address [this issue](https://github.com/O365/python-o365/issues/872#:~:text=The%20monitor%20url,the%20monitor%20request.) where the checking of the copy operation fails because the request is sent with Auth headers when not required. Feels more like a bug on the Microsoft API that they should ignore these headers when dealing with the requests (or update their docs...)