### PR TITLE
Add support for multiple Prefer headers in Connection class

### DIFF
--- a/O365/connection.py
+++ b/O365/connection.py
@@ -719,7 +719,7 @@ class Connection:
         """
         method = method.lower()
         if method not in self._allowed_methods:
-            raise ValueError('Method must be one of the allowed ones')
+            raise ValueError('Method must be one of: {}'.format(self._allowed_methods))
 
         if 'headers' not in kwargs:
             kwargs['headers'] = {**self.default_headers}
@@ -727,6 +727,8 @@ class Connection:
             for key, value in self.default_headers.items():
                 if key not in kwargs['headers']:
                     kwargs['headers'][key] = value
+                elif key == 'Prefer' and key in kwargs['headers']:
+                    kwargs['headers'][key] = "{}, {}".format(kwargs['headers'][key], value)
 
         if method == 'get':
             kwargs.setdefault('allow_redirects', True)


### PR DESCRIPTION
Added support for multiple Prefer headers in the Connection class. 
Clarified unsupported method error message.

## Added support for multiple Prefer headers in the Connection class
Assuming something like: 
```
schedule = Schedule()
schedule.con.default_headers['Prefer'] = 'IdType="ImmutableId"'
```
Using a method that has a Prefer header hardcoded in the request, like Calendar.get_event() which specifies `response = self.con.get(url, params=params, ={'Prefer': 'outlook.timezone="UTC"'})` would override `Connection.default_headers['Prefer']`. This change concatenates the values.

Before:
```
2024-01-11 11:38:04,410 DEBUG    Supplying headers {'Prefer': 'outlook.timezone="UTC"}
```
After:
```
2024-01-11 11:38:04,410 DEBUG    Supplying headers {'Prefer': 'outlook.timezone="UTC", IdType="ImmutableId"'}
```


## Clarified unsupported method error message
Assuming something like:
```
_allowed_methods = ['get', 'post', 'put', 'patch', 'delete']
```
No error when using a valid method:
```
method = 'get'
if method not in _allowed_methods:
    raise ValueError('Method must be one of: {}'.format(_allowed_methods))
```
Improved error message when using an invalid method:
```
method = 'this should fail'
if method not in _allowed_methods:
    raise ValueError('Method must be one of: {}'.format(_allowed_methods))
Traceback (most recent call last):
  File "/snap/pycharm-professional/364/plugins/python/helpers/pydev/pydevconsole.py", line 364, in runcode
    coro = func()
           ^^^^^^
  File "<input>", line 4, in <module>
ValueError: Method must be one of: ['get', 'post', 'put', 'patch', 'delete']
```