### PR TITLE
Added time zone & working hours to MailboxSettings class

### DIFF
--- a/O365/mailbox.py
+++ b/O365/mailbox.py
@@ -204,6 +204,8 @@ class MailboxSettings(ApiComponent):
         self.automaticrepliessettings = self.autoreply_constructor(
             parent=self, **{self._cloud_data_key: autorepliessettings}
         )
+        self.timezone = cloud_data.get("timeZone") 
+        self.workinghours = cloud_data.get("workingHours") 
 
     def __str__(self):
         """Representation of the MailboxSetting via the Graph api as a string."""


### PR DESCRIPTION
#### Background
For some applications that rely on user information to provide functionality, it is helpful to retrieve user data, such as the user's time zone and working hours, directly from the Microsoft Graph API instead of asking the user for this information.

#### Challenge
The current implementation of MailboxSettings does not expose the user's  time zone & working hours even though the information is retrieved from the Microsoft Graph API by the code.

#### Changes
This PR exposes the timeZone and workingHours mailbox settings to the user as class variables in the MailboxSettings class.

#### Appendix
This functionality will help in the development of  [AdminGPT](https://github.com/sdelgadoc/AdminGPT) an AI-powered administrative assistant, implemented using OpenAI's Assistant framework to seamlessly integrate with your email and calendar.

Resolves O365/python-o365#975