### PR TITLE
Add web_link property to Calendar

### DIFF
--- a/O365/calendar.py
+++ b/O365/calendar.py
@@ -927,6 +927,7 @@ class Event(ApiComponent, AttachableMixin, HandleRecipientsMixin):
         self.__show_as = EventShowAs.from_value(cloud_data.get(cc('showAs'), 'busy'))
         self.__event_type = EventType.from_value(cloud_data.get(cc('type'), 'singleInstance'))
         self.__no_forwarding = False
+        self.web_link = cloud_data.get(cc('webLink'), None)
 
     def __str__(self):
         return self.__repr__()


### PR DESCRIPTION
Adds webLink property from Event spec: https://learn.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0