### PR TITLE
Expose task status

### DIFF
--- a/O365/tasks.py
+++ b/O365/tasks.py
@@ -230,6 +230,15 @@ class Task(ApiComponent):
         self._track_changes.add(self._cc('dueDateTime'))
 
     @property
+    def status(self):
+        """Status of task
+
+        :getter: get status
+        :type: string
+        """
+        return self.__status
+
+    @property
     def completed(self):
         """ Completed Time of task
 

--- a/O365/tasks_graph.py
+++ b/O365/tasks_graph.py
@@ -290,6 +290,15 @@ class Task(ApiComponent):
         self._track_changes.add(self._cc("isReminderOn"))
 
     @property
+    def status(self):
+        """Status of task
+
+        :getter: get status
+        :type: string
+        """
+        return self.__status
+
+    @property
     def completed(self):
         """Completed Time of task.
 


### PR DESCRIPTION
Currently only derived fields are exposed, e.g. is_complete. However status can have multiple values, so should be exposed directly.