### PR TITLE
Update Excel get_used_range methods to fix/enable "onlyValues" API parameter

### DIFF
--- a/O365/excel.py
+++ b/O365/excel.py
@@ -483,7 +483,7 @@ class Range(ApiComponent):
         'get_row': '/row',
         'rows_above': '/rowsAbove(count={})',
         'rows_below': '/rowsBelow(count={})',
-        'get_used_range': '/usedRange',
+        'get_used_range': '/usedRange(valuesOnly={})',
         'clear_range': '/clear',
         'delete_range': '/delete',
         'insert_range': '/insert',
@@ -761,11 +761,12 @@ class Range(ApiComponent):
     def get_used_range(self, only_values=True):
         """
         Returns the used range of the given range object.
-        :param bool only_values: Optional.
-         Considers only cells with values as used cells.
+        :param bool only_values: Optional. Defaults to True.
+         Considers only cells with values as used cells (ignores formatting).
         :return: Range
         """
-        return self._get_range('get_used_range', valuesOnly=only_values)
+        # Format the "only_values" parameter as a lowercase string to work correctly with the Graph API 
+        return self._get_range('get_used_range', str(only_values).lower())
 
     def clear(self, apply_to='all'):
         """
@@ -1480,7 +1481,7 @@ class WorkSheet(ApiComponent):
         'get_table': '/tables/{id}',
         'get_range': '/range',
         'add_table': '/tables/add',
-        'get_used_range': '/usedRange',
+        'get_used_range': '/usedRange(valuesOnly={})',
         'get_cell': '/cell(row={row},column={column})',
         'add_named_range': '/names/add',
         'add_named_range_f': '/names/addFormulaLocal',
@@ -1614,11 +1615,15 @@ class WorkSheet(ApiComponent):
             return None
         return self.range_constructor(parent=self, **{self._cloud_data_key: response.json()})
 
-    def get_used_range(self):
+    def get_used_range(self, only_values=True):
         """ Returns the smallest range that encompasses any cells that
          have a value or formatting assigned to them.
+        :param bool only_values: Optional. Defaults to True.
+         Considers only cells with values as used cells (ignores formatting).
+        :return: Range
         """
-        url = self.build_url(self._endpoints.get('get_used_range'))
+        # Format the "only_values" parameter as a lowercase string to work properly with the Graph API 
+        url = self.build_url(self._endpoints.get('get_used_range').format(str(only_values).lower()))
         response = self.session.get(url)
         if not response:
             return None


### PR DESCRIPTION
Currently for the Excel.Range.get_used_range() and Excel.WorkSheet.get_used_range() methods, they do not work with the MS Graph API parameter "onlyValues" (for considering only Excel cells with values/ignoring empty but formatted cells).

The Excel.Range.get_used_range() method currently has an "only_values" parameter, but the Excel.Range endpoint for "get_used_range" currently does not have the "onlyValues" parameter included. So I have updated that endpoint. And since the Excel.Range.get_used_range() already has the "only_values" parameter set to default as True, I left that unchanged.

The Excel.WorkSheet.get_used_range() does not have an "only_values" parameter, so I added it. And similarly, the Excel.WorkSheet "get_used_range" endpoint also currently lacks the "onlyValues" parameter, so I added it as well. And since the Excel.Range.get_used_range() already has the "only_values" parameter set to default as True, I kept that default in this method as well.

Additionally, the "only_values" parameter needs to be converted into a lowercase string for proper functionality with the API (see example HTTP Request using the valuesOnly parameter (https://learn.microsoft.com/en-us/graph/api/worksheet-usedrange?view=graph-rest-1.0&tabs=http#request-1):
```
GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id|name}/usedRange(valuesOnly=true)
```

As for testing, I'm not sure of any great way to test these updated methods. However, please see attached screenshots from running the modified code on my machine:
![used_range_test_sheet](https://github.com/O365/python-o365/assets/59071005/6f5b4831-7196-4638-b28e-4fa894d5e7cb)
![used_range_test_code](https://github.com/O365/python-o365/assets/59071005/b9050130-371b-4e8d-b52e-9bf42f582f1c)
