### PR TITLE
Update windows_tz.py

### DIFF
--- a/O365/utils/windows_tz.py
+++ b/O365/utils/windows_tz.py
@@ -453,6 +453,7 @@ IANA_TO_WIN = {
     "Europe/Jersey": "GMT Standard Time",
     "Europe/Kaliningrad": "Kaliningrad Standard Time",
     "Europe/Kyiv": "FLE Standard Time",
+    "Europe/Kiev": "FLE Standard Time",
     "Europe/Kirov": "Russian Standard Time",
     "Europe/Lisbon": "GMT Standard Time",
     "Europe/Ljubljana": "Central European Standard Time",


### PR DESCRIPTION
In some cases linux (on WSL2) uses "Europe/Kiev" instead of "Europe/Kyiv". It's the same time zone