### PR TITLE
Add custom headers to email

### DIFF
--- a/O365/message.py
+++ b/O365/message.py
@@ -639,6 +639,14 @@ class Message(ApiComponent, AttachableMixin, HandleRecipientsMixin):
         self.__message_headers = value
         self._track_changes.add('message_headers')
 
+    def add_message_header(self, name, value):
+        # Look if we already have the key. If we do, update it, otherwise write
+        for header in self.__message_headers:
+            if header["name"] == name:
+                header["value"] = value
+                return
+        self.__message_headers.append({"name": name, "value": value})
+
     def to_api_data(self, restrict_keys=None):
         """ Returns a dict representation of this message prepared to be sent
         to the cloud

--- a/O365/message.py
+++ b/O365/message.py
@@ -686,6 +686,9 @@ class Message(ApiComponent, AttachableMixin, HandleRecipientsMixin):
             # this property does not form part of the message itself
             message[cc('parentFolderId')] = self.folder_id
 
+        if self.message_headers:
+            message[cc('internetMessageHeaders')] = self.message_headers
+
         if restrict_keys:
             for key in list(message.keys()):
                 if key not in restrict_keys:

--- a/O365/message.py
+++ b/O365/message.py
@@ -340,7 +340,7 @@ class Message(ApiComponent, AttachableMixin, HandleRecipientsMixin):
         self.web_link = cloud_data.get(cc('webLink'), '')
 
         # Headers only retrieved when selecting 'internetMessageHeaders'
-        self.message_headers = cloud_data.get(cc('internetMessageHeaders'), [])
+        self.__message_headers = cloud_data.get(cc('internetMessageHeaders'), [])
 
     def __str__(self):
         return self.__repr__()
@@ -621,6 +621,20 @@ class Message(ApiComponent, AttachableMixin, HandleRecipientsMixin):
     def single_value_extended_properties(self):
         """ singleValueExtendedProperties """
         return self.__single_value_extended_properties
+
+    @property
+    def message_headers(self):
+        """ Custom message headers
+            List of internetMessageHeaders, see definition: https://learn.microsoft.com/en-us/graph/api/resources/internetmessageheader?view=graph-rest-1.0
+        :type: list[dict[str, str]]
+        """
+
+        return self.__message_headers
+
+    @message_headers.setter
+    def message_headers(self, value):
+        self.__message_headers = value
+        self._track_changes.add('message_headers')
 
     def to_api_data(self, restrict_keys=None):
         """ Returns a dict representation of this message prepared to be sent

--- a/O365/message.py
+++ b/O365/message.py
@@ -633,6 +633,9 @@ class Message(ApiComponent, AttachableMixin, HandleRecipientsMixin):
 
     @message_headers.setter
     def message_headers(self, value):
+        if not isinstance(value, list):
+            raise ValueError('"message_header" must be a list')
+
         self.__message_headers = value
         self._track_changes.add('message_headers')
 


### PR DESCRIPTION
This a continuation on an existing PR #871 , and tries to handle the comments there. Also adding the property before the `restrict_keys` part to not sidestep that functionality.

We want to be able to send custom headers to the email, as supported in [this example i MS docs](https://learn.microsoft.com/en-us/graph/api/user-post-messages?view=graph-rest-1.0&tabs=http#example-2-create-message-draft-that-includes-custom-message-headers). 

I added two unit tests to verify the behavior ~but I wasn't able to test it with the live environment~. I've tested it with my O365-account and I think it works as expected.