### PR TITLE
Added angled brackets instead of braces to repr of recipient

### DIFF
--- a/O365/utils/utils.py
+++ b/O365/utils/utils.py
@@ -122,7 +122,7 @@ class Recipient:
 
     def __repr__(self):
         if self.name:
-            return '{} ({})'.format(self.name, self.address)
+            return '{} <{}>'.format(self.name, self.address)
         else:
             return self.address
 

--- a/tests/test_recipient.py
+++ b/tests/test_recipient.py
@@ -1,0 +1,21 @@
+import pytest
+
+from O365.utils import Recipient
+
+
+class TestRecipient:
+    def setup_class(self):
+        pass
+
+    def teardown_class(self):
+        pass
+
+    def test_recipient_str(self):
+        recipient = Recipient()
+        assert str(recipient) == ""
+
+        recipient = Recipient(address="john@example.com")
+        assert str(recipient) == "john@example.com"
+
+        recipient = Recipient(address="john@example.com", name="John Doe")
+        assert str(recipient) == "John Doe <john@example.com>"


### PR DESCRIPTION
 - Added angled brackets instead of braces to repr of recipient
 - Decided against adding quotation marks around the name part, as this isn't done by the built in `imap`/`email` representation either.
 - Added unit tests to test stringifying recipient