### PR TITLE
fixing itemAt endpoint to new structure

### DIFF
--- a/O365/excel.py
+++ b/O365/excel.py
@@ -1334,7 +1334,8 @@ class Table(ApiComponent):
             return None
 
         url = self.build_url(self._endpoints.get('get_row_index'))
-        response = self.session.post(url, data={'index': index})
+        url = '{}(index={})'.format(url, index)
+        response = self.session.get(url)
 
         if not response:
             return None


### PR DESCRIPTION
Table Row operations are not aligned anymore with Microsoft Graph Docs 
https://learn.microsoft.com/en-us/graph/api/tablerowcollection-itemat?view=graph-rest-1.0&tabs=http

See also here, but this did not fully fix the issue
https://github.com/O365/python-o365/pull/849

could you please review and merge if this is fine?
