### PR TITLE
User: add ability to access onPremisesSamAccountName

### DIFF
--- a/O365/directory.py
+++ b/O365/directory.py
@@ -116,6 +116,7 @@ class User(ApiComponent):
         self.street_address = cloud_data.get(cc('streetAddress'))
         self.usage_location = cloud_data.get(cc('usageLocation'))
         self.user_type = cloud_data.get(cc('userType'))
+        self.on_premises_sam_account_name = cloud_data.get(cc('onPremisesSamAccountName'))
 
     def __str__(self):
         return self.__repr__()


### PR DESCRIPTION
The User object has everything I need... except the ability to access the onPremisesSamAccountName to be able to integrate with on-prem applications.

I feel like I agree with [this comment](https://github.com/O365/python-o365/issues/298#issuecomment-528493118) of having a way of providing access to these sort of 'niche' attributes without needing to modify the object - perhaps just exposing a way to accessing the cloud data - but I can't see a way of achieving this with the current code, so here is a pull request to provide access to my new niche attribute :) 

