### PR TITLE
fix: correct scope parameter from 'sharepoint_dl' to 'sharepoint_all'…

### DIFF
--- a/O365/connection.py
+++ b/O365/connection.py
@@ -53,7 +53,7 @@ DEFAULT_SCOPES = {
     'onedrive': ['Files.Read.All'],
     'onedrive_all': ['Files.ReadWrite.All'],
     'sharepoint': ['Sites.Read.All'],
-    'sharepoint_dl': ['Sites.ReadWrite.All'],
+    'sharepoint_all': ['Sites.ReadWrite.All'],
     'settings_all': ['MailboxSettings.ReadWrite'],
     'tasks': ['Tasks.Read'],
     'tasks_all': ['Tasks.ReadWrite'],


### PR DESCRIPTION
… as per documentation

The application was using the scope parameter 'sharepoint_all', which caused an error because it doesn't exist on the resource. According to the documentation, the correct scope parameter is 'sharepoint_all'. This commit updates the scope parameter to 'sharepoint_all' to resolve the issue.

Error details:

The application 'APP NAME' asked for scope 'sharepoint_all' that doesn't exist on the resource 'RESOURCE NAME'. Contact the app vendor. Trace ID: "Trace ID" Correlation ID: CORRELATION ID Timestamp: Timestamp Something go wrong. Please try again.