### PR TITLE
Update to support unsetting tasks due and reminder

### DIFF
--- a/O365/tasks_graph.py
+++ b/O365/tasks_graph.py
@@ -1,4 +1,5 @@
 """Methods for accessing MS Tasks/Todos via the MS Graph api."""
+
 import datetime as dt
 import logging
 
@@ -139,14 +140,15 @@ class Task(ApiComponent):
 
         if self.__due:
             data[cc("dueDateTime")] = self._build_date_time_time_zone(self.__due)
+        else:
+            data[cc("dueDateTime")] = None
 
         if self.__reminder:
             data[cc("reminderDateTime")] = self._build_date_time_time_zone(
                 self.__reminder
             )
-            data[cc("isReminderOn")] = True
         else:
-            data[cc("isReminderOn")] = False
+            data[cc("reminderDateTime")] = None
 
         if self.__completed:
             data[cc("completedDateTime")] = self._build_date_time_time_zone(
@@ -235,16 +237,17 @@ class Task(ApiComponent):
 
     @due.setter
     def due(self, value):
-        if not isinstance(value, dt.date):
-            raise ValueError("'due' must be a valid datetime object")
-        if not isinstance(value, dt.datetime):
-            # force datetime
-            value = dt.datetime(value.year, value.month, value.day)
-        if value.tzinfo is None:
-            # localize datetime
-            value = value.replace(tzinfo=self.protocol.timezone)
-        elif value.tzinfo != self.protocol.timezone:
-            value = value.astimezone(self.protocol.timezone)
+        if value:
+            if not isinstance(value, dt.date):
+                raise ValueError("'due' must be a valid datetime object")
+            if not isinstance(value, dt.datetime):
+                # force datetime
+                value = dt.datetime(value.year, value.month, value.day)
+            if value.tzinfo is None:
+                # localize datetime
+                value = value.replace(tzinfo=self.protocol.timezone)
+            elif value.tzinfo != self.protocol.timezone:
+                value = value.astimezone(self.protocol.timezone)
         self.__due = value
         self._track_changes.add(self._cc("dueDateTime"))
 
@@ -260,18 +263,18 @@ class Task(ApiComponent):
 
     @reminder.setter
     def reminder(self, value):
-        if not isinstance(value, dt.date):
-            raise ValueError("'reminder' must be a valid datetime object")
-        if not isinstance(value, dt.datetime):
-            # force datetime
-            value = dt.datetime(value.year, value.month, value.day)
-        if value.tzinfo is None:
-            # localize datetime
-            value = value.replace(tzinfo=self.protocol.timezone)
-        elif value.tzinfo != self.protocol.timezone:
-            value = value.astimezone(self.protocol.timezone)
+        if value:
+            if not isinstance(value, dt.date):
+                raise ValueError("'reminder' must be a valid datetime object")
+            if not isinstance(value, dt.datetime):
+                # force datetime
+                value = dt.datetime(value.year, value.month, value.day)
+            if value.tzinfo is None:
+                # localize datetime
+                value = value.replace(tzinfo=self.protocol.timezone)
+            elif value.tzinfo != self.protocol.timezone:
+                value = value.astimezone(self.protocol.timezone)
         self.__reminder = value
-        self.is_reminder_on = True
         self._track_changes.add(self._cc("reminderDateTime"))
 
     @property
@@ -279,15 +282,9 @@ class Task(ApiComponent):
         """Return isReminderOn of the task.
 
         :getter: Get isReminderOn
-        :setter: Set isReminderOn
         :type: bool
         """
         return self.__is_reminder_on
-
-    @is_reminder_on.setter
-    def is_reminder_on(self, value):
-        self.__is_reminder_on = value
-        self._track_changes.add(self._cc("isReminderOn"))
 
     @property
     def status(self):


### PR DESCRIPTION
This allows unsetting of due and reminder date/times. Also it removes the setter for is_reminder_on because the isReminderOn is controlled by MS Graph based on whether there is a reminder set. There is no value in setting it.

I have not modified tasks.py (which is the office api version) because that api seems to have been deprecated since November 2024, see my comment on the issue.

https://github.com/O365/python-o365/issues/1126