### PR TITLE
Modify to handle threads using same account/connection object

### DIFF
--- a/O365/connection.py
+++ b/O365/connection.py
@@ -970,14 +970,17 @@ class Connection:
         self._previous_request_at = time.time()
 
     def _internal_request(
-        self, session_obj: Session, url: str, method: str, ignore401: bool, **kwargs
+        self, session_obj: Session, url: str, method: str, ignore401: bool = False, **kwargs
     ) -> Response:
         """Internal handling of requests. Handles Exceptions.
 
         :param session_obj: a requests Session instance.
         :param str url: url to send request to
         :param str method: type of request (get/put/post/patch/delete)
-        :param bool ignore401: indicates whether to ignore 401 error or not
+        :param bool ignore401: indicates whether to ignore 401 error when it would 
+          indicate that there the token has expired. This is set to 'True' for the
+          first call to the api, and 'False' for the call that is initiated after a 
+          tpken refresh. 
         :param kwargs: extra params to send to the request api
         :return: Response of the request
         :rtype: requests.Response
@@ -1095,7 +1098,7 @@ class Connection:
             # lazy creation of a naive session
             self.naive_session = self.get_naive_session()
 
-        return self._internal_request(self.naive_session, url, method, ignore401=False **kwargs)
+        return self._internal_request(self.naive_session, url, method, ignore401=False, **kwargs)
 
     def oauth_request(self, url: str, method: str, **kwargs) -> Response:
         """Makes a request to url using an oauth session.

--- a/examples/token_backends.py
+++ b/examples/token_backends.py
@@ -199,10 +199,13 @@ class LockableFileSystemTokenBackend(FileSystemTokenBackend):
                 log.debug(f"Oauth file locked. Sleeping for 2 seconds... retrying {i - 1} more times.")
                 time.sleep(2)
                 log.debug("Waking up and rechecking token file for update from other instance...")
-                # Assume the token has been already updated
+                # Check if new token has been created.
                 self.load_token()
-                # Return False so the connection can update the token access from the backend into the session
-                return False
+                if not self.token_is_expired():
+                    log.debug("Token file has been updated in other instance...")
+                    # Return False so the connection can update the token access from the
+                    # backend into the session
+                    return False
 
         # if we exit the loop, that means we were locked out of the file after
         # multiple retries give up and throw an error - something isn't right


### PR DESCRIPTION
I've made two modifications to this, one in connection.py and one in the examples. Both of these I have tested through, and without the changes I get 401 errors.

connection.py - I've changed the method of how the 401 error is ignored. This is because in my app, multiple threads are using the same account/connection object, so the existing flag was already set to True for any threads after the first that were doing a query. What I believe is required is that all queries get two chances in `oauth_request`, so the first call to `_internal_request` should 'ignore' a 401 and raise a TokenExpiredError, and the second call should raise the 401 error if repeated.

token_backends.py - The existing example did not loop (default max 3 times) while the second thread (when finding the file locked) waited for the token to be refreshed.