### PR TITLE
Remove Office 365 Protocol and documentation

### DIFF
--- a/O365/__init__.py
+++ b/O365/__init__.py
@@ -1,5 +1,5 @@
 """
-A simple python library to interact with Microsoft Graph and Office 365 API
+A simple python library to interact with Microsoft Graph
 """
 import warnings
 import sys
@@ -7,7 +7,7 @@ import sys
 from .__version__ import __version__
 
 from .account import Account
-from .connection import Connection, Protocol, MSGraphProtocol, MSOffice365Protocol
+from .connection import Connection, Protocol, MSGraphProtocol
 from .utils import FileSystemTokenBackend, EnvTokenBackend
 from .message import Message
 

--- a/O365/__init__.py
+++ b/O365/__init__.py
@@ -1,6 +1,7 @@
 """
-A simple python library to interact with Microsoft Graph
+A simple python library to interact with Microsoft Graph and other MS api
 """
+
 import warnings
 import sys
 
@@ -14,4 +15,4 @@ from .message import Message
 
 if sys.warnoptions:
     # allow Deprecation warnings to appear
-    warnings.simplefilter('always', DeprecationWarning)
+    warnings.simplefilter("always", DeprecationWarning)

--- a/O365/address_book.py
+++ b/O365/address_book.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class Contact(ApiComponent, AttachableMixin):
-    """ Contact manages lists of events on associated contact on office365. """
+    """ Contact manages lists of events on associated contact on Microsoft 365. """
 
     _endpoints = {
         'contact': '/contacts',

--- a/O365/connection.py
+++ b/O365/connection.py
@@ -34,7 +34,6 @@ from .utils import (
 
 log = logging.getLogger(__name__)
 
-O365_API_VERSION: str = "v2.0"
 GRAPH_API_VERSION: str = "v1.0"
 OAUTH_REDIRECT_URL: str = "https://login.microsoftonline.com/common/oauth2/nativeclient"
 
@@ -193,8 +192,6 @@ class Protocol:
         When using Microsoft Graph API, the keywords of the API use
         lowerCamelCase Casing
 
-        When using Office 365 API, the keywords of the API use PascalCase Casing
-
         Default case in this API is lowerCamelCase
 
         :param  key: a dictionary key to convert
@@ -298,62 +295,9 @@ class MSGraphProtocol(Protocol):
         )
 
 
-class MSOffice365Protocol(Protocol):
-    """A Microsoft Office 365 Protocol Implementation
-    https://docs.microsoft.com/en-us/outlook/rest/compare-graph-outlook
-    """
-
-    _protocol_url = "https://outlook.office.com/api/"
-    _oauth_scope_prefix = "https://outlook.office.com/"
-    _oauth_scopes = DEFAULT_SCOPES
-
-    def __init__(self, api_version: str = "v2.0", default_resource: Optional[str] = None, **kwargs):
-        """Create a new Office 365 protocol object
-
-        _protocol_url = 'https://outlook.office.com/api/'
-
-        _oauth_scope_prefix = 'https://outlook.office.com/'
-
-        :param str api_version: api version to use
-        :param str default_resource: the default resource to use when there is
-         nothing explicitly specified during the requests
-        """
-        super().__init__(
-            protocol_url=self._protocol_url,
-            api_version=api_version,
-            default_resource=default_resource,
-            casing_function=to_pascal_case,
-            protocol_scope_prefix=self._oauth_scope_prefix,
-            **kwargs,
-        )
-
-        self.keyword_data_store["message_type"] = "Microsoft.OutlookServices.Message"
-        self.keyword_data_store["event_message_type"] = (
-            "Microsoft.OutlookServices.EventMessage"
-        )
-        self.keyword_data_store["file_attachment_type"] = (
-            "#Microsoft.OutlookServices.FileAttachment"
-        )
-        self.keyword_data_store["item_attachment_type"] = (
-            "#Microsoft.OutlookServices.ItemAttachment"
-        )
-        self.keyword_data_store["prefer_timezone_header"] = (
-            f'outlook.timezone="{get_windows_tz(self.timezone)}"'
-        )
-        #: The max value for 'top' (999).  |br| **Type:** str
-        self.max_top_value = 999  # Max $top parameter value
-
-    @Protocol.timezone.setter
-    def timezone(self, timezone: Union[str, ZoneInfo]) -> None:
-        super()._update_timezone(timezone)
-        self.keyword_data_store["prefer_timezone_header"] = (
-            f'outlook.timezone="{get_windows_tz(self._timezone)}"'
-        )
-
-
 class MSBusinessCentral365Protocol(Protocol):
     """A Microsoft Business Central Protocol Implementation
-    https://docs.microsoft.com/en-us/dynamics-nav/api-reference/v1.0/endpoints-apis-for-dynamics
+    https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/api-reference/v1.0/
     """
 
     _protocol_url = "https://api.businesscentral.dynamics.com/"

--- a/O365/excel.py
+++ b/O365/excel.py
@@ -9,7 +9,6 @@ import logging
 import re
 from urllib.parse import quote
 
-from .connection import MSOffice365Protocol
 from .drive import File
 from .utils import ApiComponent, TrackerSet, to_snake_case
 
@@ -2065,11 +2064,6 @@ class WorkBook(ApiComponent):
             or file_item.mime_type != EXCEL_XLSX_MIME_TYPE
         ):
             raise ValueError("This file is not a valid Excel xlsx file.")
-
-        if isinstance(file_item.protocol, MSOffice365Protocol):
-            raise ValueError(
-                "Excel capabilities are only allowed on the MSGraph protocol"
-            )
 
         # append the workbook path
         main_resource = "{}{}/workbook".format(

--- a/O365/groups.py
+++ b/O365/groups.py
@@ -7,7 +7,7 @@ log = logging.getLogger(__name__)
 
 
 class Group(ApiComponent):
-    """ A Microsoft O365 group """
+    """ A Microsoft 365 group """
 
     _endpoints = {
             'get_group_owners': '/groups/{group_id}/owners',
@@ -17,7 +17,7 @@ class Group(ApiComponent):
     member_constructor = User  #: :meta private:
 
     def __init__(self, *, parent=None, con=None, **kwargs):
-        """ A Microsoft O365 group
+        """ A Microsoft 365 group
 
         :param parent: parent object
         :type parent: Teams
@@ -156,7 +156,7 @@ class Groups(ApiComponent):
         return 'Microsoft O365 Group parent class'
 
     def get_group_by_id(self, group_id = None):
-        """ Returns Microsoft O365/AD group with given id
+        """ Returns Microsoft 365/AD group with given id
 
         :param group_id: group id of group
 
@@ -181,7 +181,7 @@ class Groups(ApiComponent):
         return self.group_constructor(parent=self, **{self._cloud_data_key: data})
 
     def get_group_by_mail(self, group_mail=None):
-        """Returns Microsoft O365/AD group by mail field
+        """Returns Microsoft 365/AD group by mail field
 
         :param group_name: mail of group
 

--- a/O365/message.py
+++ b/O365/message.py
@@ -1160,16 +1160,8 @@ class Message(ApiComponent, AttachableMixin, HandleRecipientsMixin):
             self.object_id = message.get(self._cc('id'), None)
             self.folder_id = message.get(self._cc('parentFolderId'), None)
 
-            # fallback to office365 v1.0
-            self.__created = message.get(self._cc('createdDateTime'),
-                                         message.get(
-                                             self._cc('dateTimeCreated'),
-                                             None))
-            # fallback to office365 v1.0
-            self.__modified = message.get(self._cc('lastModifiedDateTime'),
-                                          message.get(
-                                              self._cc('dateTimeModified'),
-                                              None))
+            self.__created = message.get(self._cc('createdDateTime'),None)
+            self.__modified = message.get(self._cc('lastModifiedDateTime'),None)
 
             self.__created = parse(self.__created).astimezone(
                 self.protocol.timezone) if self.__created else None

--- a/O365/planner.py
+++ b/O365/planner.py
@@ -12,7 +12,7 @@ class TaskDetails(ApiComponent):
     _endpoints = {"task_detail": "/planner/tasks/{id}/details"}
 
     def __init__(self, *, parent=None, con=None, **kwargs):
-        """A Microsoft O365 plan details
+        """A Microsoft 365 plan details
 
         :param parent: parent object
         :type parent: Task
@@ -180,7 +180,7 @@ class PlanDetails(ApiComponent):
     _endpoints = {"plan_detail": "/planner/plans/{id}/details"}
 
     def __init__(self, *, parent=None, con=None, **kwargs):
-        """A Microsoft O365 plan details
+        """A Microsoft 365 plan details
 
         :param parent: parent object
         :type parent: Plan
@@ -386,7 +386,7 @@ class Task(ApiComponent):
         return self.object_id == other.object_id
 
     def get_details(self):
-        """Returns Microsoft O365/AD plan with given id
+        """Returns Microsoft 365/AD plan with given id
 
         :rtype: PlanDetails
         """
@@ -507,7 +507,7 @@ class Bucket(ApiComponent):
     task_constructor = Task  #: :meta private:
 
     def __init__(self, *, parent=None, con=None, **kwargs):
-        """A Microsoft O365 bucket
+        """A Microsoft 365 bucket
 
         :param parent: parent object
         :type parent: Planner or Plan
@@ -751,7 +751,7 @@ class Plan(ApiComponent):
     plan_details_constructor = PlanDetails  #: :meta private:
 
     def __init__(self, *, parent=None, con=None, **kwargs):
-        """A Microsoft O365 plan
+        """A Microsoft 365 plan
 
         :param parent: parent object
         :type parent: Planner
@@ -861,7 +861,7 @@ class Plan(ApiComponent):
             return tasks
 
     def get_details(self):
-        """Returns Microsoft O365/AD plan with given id
+        """Returns Microsoft 365/AD plan with given id
 
         :rtype: PlanDetails
         """
@@ -1040,7 +1040,7 @@ class Planner(ApiComponent):
         ]
 
     def get_plan_by_id(self, plan_id=None):
-        """Returns Microsoft O365/AD plan with given id
+        """Returns Microsoft 365/AD plan with given id
 
         :param plan_id: plan id of plan
 
@@ -1067,7 +1067,7 @@ class Planner(ApiComponent):
         )
 
     def get_bucket_by_id(self, bucket_id=None):
-        """Returns Microsoft O365/AD plan with given id
+        """Returns Microsoft 365/AD plan with given id
 
         :param bucket_id: bucket id of buckets
 
@@ -1091,7 +1091,7 @@ class Planner(ApiComponent):
         return self.bucket_constructor(parent=self, **{self._cloud_data_key: data})
 
     def get_task_by_id(self, task_id=None):
-        """Returns Microsoft O365/AD plan with given id
+        """Returns Microsoft 365/AD plan with given id
 
         :param task_id: task id of tasks
 
@@ -1115,7 +1115,7 @@ class Planner(ApiComponent):
         return self.task_constructor(parent=self, **{self._cloud_data_key: data})
 
     def list_user_tasks(self, user_id=None):
-        """Returns Microsoft O365/AD plan with given id
+        """Returns Microsoft 365/AD plan with given id
 
         :param user_id: user id
 

--- a/O365/utils/utils.py
+++ b/O365/utils/utils.py
@@ -21,7 +21,7 @@ NEXT_LINK_KEYWORD = '@odata.nextLink'
 
 log = logging.getLogger(__name__)
 
-MAX_RECIPIENTS_PER_MESSAGE = 500  # Actual limit on Office 365
+MAX_RECIPIENTS_PER_MESSAGE = 500  # Actual limit on Microsoft 365
 
 
 class CaseEnum(Enum):

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # O365 - Microsoft Graph and Office 365 API made easy
 
-This project aims to make interacting with Microsoft Graph and Office 365 easy to do in a Pythonic way.
+This project aims to make interacting with the Microsoft Graph api easy to do in a Pythonic way.
 Access to Email, Calendar, Contacts, OneDrive, etc. Are easy to do in a way that feel easy and straight forward to beginners and feels just right to seasoned python programmer.
 
 The project is currently developed and maintained by [alejcas](https://github.com/alejcas).
@@ -35,8 +35,8 @@ m.send()
 
 
 ### Why choose O365?
-- Almost Full Support for MsGraph and Office 365 Rest Api.
-- Good Abstraction layer between each Api. Change the api (Graph vs Office365) and don't worry about the api internal implementation.
+- Almost Full Support for MsGraph Rest Api.
+- Good Abstraction layer for the Api.
 - Full oauth support with automatic handling of refresh tokens.
 - Automatic handling between local datetimes and server datetimes. Work with your local datetime and let this library do the rest.
 - Change between different resource with ease: access shared mailboxes, other users resources, SharePoint resources, etc.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 [![PyPI](https://img.shields.io/pypi/v/O365.svg)](https://pypi.python.org/pypi/O365)
 [![PyPI pyversions](https://img.shields.io/pypi/pyversions/O365.svg)](https://pypi.python.org/pypi/O365/)
 
-# O365 - Microsoft Graph and Office 365 API made easy
+# O365 - Microsoft Graph and related APIs made easy
 
-This project aims to make interacting with the Microsoft Graph api easy to do in a Pythonic way.
-Access to Email, Calendar, Contacts, OneDrive, etc. Are easy to do in a way that feel easy and straight forward to beginners and feels just right to seasoned python programmer.
+This project aims to make interacting with the Microsoft api, and related apis, easy to do in a Pythonic way.
+Access to Email, Calendar, Contacts, OneDrive, Sharepoint, etc. Are easy to do in a way that feel easy and straight forward to beginners and feels just right to seasoned python programmer.
 
 The project is currently developed and maintained by [alejcas](https://github.com/alejcas).
 

--- a/docs/source/usage/connection.rst
+++ b/docs/source/usage/connection.rst
@@ -87,6 +87,6 @@ Usually you will work with the default 'ME' resource, but you can also use one o
 * 'me': the user which has given consent. The default for every protocol. Overwritten when using "with your own identity" authentication method (Only available on the authorization auth_flow_type).
 * 'user:user@domain.com': a shared mailbox or a user account for which you have permissions. If you don't provide 'user:' it will be inferred anyway.
 * 'site:sharepoint-site-id': a Sharepoint site id.
-* 'group:group-site-id': an Office 365 group id.
+* 'group:group-site-id': an Microsoft 365 group id.
 
 By setting the resource prefix (such as 'user:' or 'group:') you help the library understand the type of resource. You can also pass it like 'users/example@exampl.com'. The same applies to the other resource prefixes.

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author_email='alejcas@users.noreply.github.com',
     maintainer='alejcas',
     maintainer_email='alejcas@users.noreply.github.com',
-    description='Microsoft Graph and Office 365 API made easy',
+    description='Microsoft Graph API made easy',
     long_description=read('README.md'),
     long_description_content_type="text/markdown",
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
Office 365 api is no linger available from Microsoft, so this PR is to remove it. If you disagree, then feel free to reject.

I've also change mention of Office 365, (where it does not relate to the Office 365 API), to Microsoft 365 in line with current MS branding.