### PR TITLE
Add ability to use full query to list_calendars

### DIFF
--- a/O365/calendar.py
+++ b/O365/calendar.py
@@ -1994,7 +1994,10 @@ class Schedule(ApiComponent):
             batch = self.protocol.max_top_value
         params['$top'] =  batch if batch else limit
         if query:
-            params['$filter'] = str(query)
+            if isinstance(query, str):
+                params["$filter"] = query
+            else:
+                params.update(query.as_params())
         if order_by:
             params['$orderby'] = order_by
 


### PR DESCRIPTION
In support of this issue - https://github.com/O365/python-o365/issues/1168 - this enables full query support on list_calendars. Currently the string of the query is used `str(query)`. I don't know if this will break existing usages, but it seems incorrect to not have full query support.

New code is:

```python
        if query:
            if isinstance(query, str):
                params["$filter"] = query
            else:
                params.update(query.as_params())
```