### PR TITLE
Adding group add/remove owner and member

### DIFF
--- a/O365/groups.py
+++ b/O365/groups.py
@@ -137,10 +137,6 @@ class Group(ApiComponent):
 
     def _remove_member(self, user, url_key):
 
-        #log.debug(f"url_key: { url_key }")
-        #log.debug(f"endpoint: { self._endpoints.get(url_key) }")
-
-
         if isinstance(user, User):
             object_id = user.id
         elif isinstance(user, str):


### PR DESCRIPTION
The Group object had methods for retrieving members and owners, but not removing or adding them.

The PR adds those methods.